### PR TITLE
Add more detail to search results

### DIFF
--- a/src/modals/MediaDbSearchResultModal.ts
+++ b/src/modals/MediaDbSearchResultModal.ts
@@ -29,7 +29,7 @@ export class MediaDbSearchResultModal extends SelectModal<MediaTypeModel> {
 	// Renders each suggestion item.
 	renderElement(item: MediaTypeModel, el: HTMLElement) {
 		el.createEl('div', {text: this.plugin.mediaTypeManager.getFileName(item)});
-		el.createEl('small', {text: `${item.englishTitle}\n`});
+		el.createEl('small', {text: `${item.getSummary()}\n`});
 		el.createEl('small', {text: `${item.type.toUpperCase() + (item.subType ? ` (${item.subType})` : '')} from ${item.dataSource}`});
 	}
 

--- a/src/models/GameModel.ts
+++ b/src/models/GameModel.ts
@@ -42,4 +42,8 @@ export class GameModel extends MediaTypeModel {
 		return MediaType.Game;
 	}
 
+	getSummary(): string {
+		return this.englishTitle + ' (' + this.year + ')';
+	}
+
 }

--- a/src/models/MediaTypeModel.ts
+++ b/src/models/MediaTypeModel.ts
@@ -14,6 +14,9 @@ export abstract class MediaTypeModel {
 
 	abstract getMediaType(): MediaType;
 
+	//a string that contains enough info to disambiguate from similar media
+	abstract getSummary(): string;
+
 	abstract getTags(): string[];
 
 	toMetaDataObject(): object {

--- a/src/models/MovieModel.ts
+++ b/src/models/MovieModel.ts
@@ -44,4 +44,7 @@ export class MovieModel extends MediaTypeModel {
 		return MediaType.Movie;
 	}
 
+	getSummary(): string {
+		return this.englishTitle + ' (' + this.year + ')';
+	}
 }

--- a/src/models/MusicReleaseModel.ts
+++ b/src/models/MusicReleaseModel.ts
@@ -37,4 +37,10 @@ export class MusicReleaseModel extends MediaTypeModel {
 		return MediaType.MusicRelease;
 	}
 
+	getSummary(): string {
+		var summary = this.title + ' (' + this.year + ')';
+		if(this.artists.length > 0)
+			summary += ' - ' + this.artists.join(', ')
+		return summary;
+	}
 }

--- a/src/models/SeriesModel.ts
+++ b/src/models/SeriesModel.ts
@@ -47,4 +47,7 @@ export class SeriesModel extends MediaTypeModel {
 		return MediaType.Series;
 	}
 
+	getSummary(): string {
+		return this.title + ' (' + this.year + ')';
+	}
 }

--- a/src/models/WikiModel.ts
+++ b/src/models/WikiModel.ts
@@ -43,4 +43,7 @@ export class WikiModel extends MediaTypeModel {
 		return copy;
 	}
 
+	getSummary(): string {
+		return this.title;
+	}
 }


### PR DESCRIPTION
If you change the file format of files generated by this plugin, it can make searching for media confusing. For example if the files are changed to simply be an album name.

This PR adds getSummary to the MediaTypeModel.ts abstract class, which allows individual models to give more detail to better allow people to pick the right result.

The only model I have updated to be especially more verbose is the music release as this is the one that I had trouble with.

Before:

![image](https://user-images.githubusercontent.com/9056681/186193840-6886e8a8-3564-4756-81ea-6703aa6d8c14.png)

After:

![image](https://user-images.githubusercontent.com/9056681/186195231-a9382d6d-2c07-4d30-8307-926112680da0.png)
