### PR TITLE
add feature to customize date formatting

### DIFF
--- a/src/api/apis/MALAPI.ts
+++ b/src/api/apis/MALAPI.ts
@@ -8,6 +8,7 @@ import { MediaType } from '../../utils/MediaType';
 export class MALAPI extends APIModel {
 	plugin: MediaDbPlugin;
 	typeMappings: Map<string, string>;
+	apiDateFormat: string = 'YYYY-MM-DDTHH:mm:ssZ'; // ISO
 
 	constructor(plugin: MediaDbPlugin) {
 		super();
@@ -115,7 +116,7 @@ export class MALAPI extends APIModel {
 				image: result.images?.jpg?.image_url ?? '',
 
 				released: true,
-				premiere: new Date(result.aired?.from).toLocaleDateString() ?? 'unknown',
+				premiere: this.plugin.dateFormatter.format(result.aired?.from, this.apiDateFormat) ?? 'unknown',
 				streamingServices: result.streaming?.map((x: any) => x.name) ?? [],
 
 				userData: {
@@ -146,7 +147,7 @@ export class MALAPI extends APIModel {
 				image: result.images?.jpg?.image_url ?? '',
 
 				released: true,
-				premiere: new Date(result.aired?.from).toLocaleDateString() ?? 'unknown',
+				premiere: this.plugin.dateFormatter.format(result.aired?.from, this.apiDateFormat) ?? 'unknown',
 				streamingServices: result.streaming?.map((x: any) => x.name) ?? [],
 
 				userData: {
@@ -176,8 +177,8 @@ export class MALAPI extends APIModel {
 				image: result.images?.jpg?.image_url ?? '',
 
 				released: true,
-				airedFrom: new Date(result.aired?.from).toLocaleDateString() ?? 'unknown',
-				airedTo: new Date(result.aired?.to).toLocaleDateString() ?? 'unknown',
+				airedFrom: this.plugin.dateFormatter.format(result.aired?.from, this.apiDateFormat) ?? 'unknown',
+				airedTo: this.plugin.dateFormatter.format(result.aired?.to, this.apiDateFormat) ?? 'unknown',
 				airing: result.airing,
 
 				userData: {

--- a/src/api/apis/OMDbAPI.ts
+++ b/src/api/apis/OMDbAPI.ts
@@ -9,6 +9,7 @@ import { MediaType } from '../../utils/MediaType';
 export class OMDbAPI extends APIModel {
 	plugin: MediaDbPlugin;
 	typeMappings: Map<string, string>;
+	apiDateFormat: string = 'DD MMM YYYY';
 
 	constructor(plugin: MediaDbPlugin) {
 		super();
@@ -142,7 +143,7 @@ export class OMDbAPI extends APIModel {
 
 				released: true,
 				streamingServices: [],
-				premiere: new Date(result.Released).toLocaleDateString() ?? 'unknown',
+				premiere: this.plugin.dateFormatter.format(result.Released, this.apiDateFormat) ?? 'unknown',
 
 				userData: {
 					watched: false,
@@ -173,7 +174,7 @@ export class OMDbAPI extends APIModel {
 				released: true,
 				streamingServices: [],
 				airing: false,
-				airedFrom: new Date(result.Released).toLocaleDateString() ?? 'unknown',
+				airedFrom: this.plugin.dateFormatter.format(result.Released, this.apiDateFormat) ?? 'unknown',
 				airedTo: 'unknown',
 
 				userData: {
@@ -199,7 +200,7 @@ export class OMDbAPI extends APIModel {
 				image: result.Poster ?? '',
 
 				released: true,
-				releaseDate: new Date(result.Released).toLocaleDateString() ?? 'unknown',
+				releaseDate: this.plugin.dateFormatter.format(result.Released, this.apiDateFormat) ?? 'unknown',
 
 				userData: {
 					played: false,

--- a/src/api/apis/SteamAPI.ts
+++ b/src/api/apis/SteamAPI.ts
@@ -8,6 +8,7 @@ import { MediaType } from '../../utils/MediaType';
 export class SteamAPI extends APIModel {
 	plugin: MediaDbPlugin;
 	typeMappings: Map<string, string>;
+	apiDateFormat: string = 'DD MMM, YYYY';
 
 	constructor(plugin: MediaDbPlugin) {
 		super();
@@ -109,7 +110,7 @@ export class SteamAPI extends APIModel {
 			image: result.header_image ?? '',
 
 			released: !result.release_date?.comming_soon,
-			releaseDate: new Date(result.release_date?.date).toLocaleDateString() ?? 'unknown',
+			releaseDate: this.plugin.dateFormatter.format(result.release_date?.date, this.apiDateFormat) ?? 'unknown',
 
 			userData: {
 				played: false,

--- a/src/api/apis/WikipediaAPI.ts
+++ b/src/api/apis/WikipediaAPI.ts
@@ -6,6 +6,7 @@ import { MediaType } from '../../utils/MediaType';
 
 export class WikipediaAPI extends APIModel {
 	plugin: MediaDbPlugin;
+	apiDateFormat: string = 'YYYY-MM-DDTHH:mm:ssZ'; // ISO
 
 	constructor(plugin: MediaDbPlugin) {
 		super();
@@ -72,7 +73,7 @@ export class WikipediaAPI extends APIModel {
 			id: result.pageid,
 
 			wikiUrl: result.fullurl,
-			lastUpdated: new Date(result.touched).toLocaleDateString() ?? 'unknown',
+			lastUpdated: this.plugin.dateFormatter.format(result.touched, this.apiDateFormat),
 			length: result.length,
 
 			userData: {},

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import { YAMLConverter } from './utils/YAMLConverter';
 import { MediaDbFolderImportModal } from './modals/MediaDbFolderImportModal';
 import { PropertyMapping, PropertyMappingModel } from './settings/PropertyMapping';
 import { ModalHelper, ModalResultCode, SearchModalOptions } from './utils/ModalHelper';
+import { DateFormatter } from './utils/DateFormatter';
 
 export default class MediaDbPlugin extends Plugin {
 	settings: MediaDbPluginSettings;
@@ -22,6 +23,7 @@ export default class MediaDbPlugin extends Plugin {
 	mediaTypeManager: MediaTypeManager;
 	modelPropertyMapper: PropertyMapper;
 	modalHelper: ModalHelper;
+	dateFormatter: DateFormatter;
 
 	frontMatterRexExpPattern: string = '^(---)\\n[\\s\\S]*?\\n---';
 
@@ -39,6 +41,7 @@ export default class MediaDbPlugin extends Plugin {
 		this.mediaTypeManager = new MediaTypeManager();
 		this.modelPropertyMapper = new PropertyMapper(this);
 		this.modalHelper = new ModalHelper(this);
+		this.dateFormatter = new DateFormatter();
 
 		await this.loadSettings();
 		// register the settings tab
@@ -46,6 +49,7 @@ export default class MediaDbPlugin extends Plugin {
 
 		this.mediaTypeManager.updateTemplates(this.settings);
 		this.mediaTypeManager.updateFolders(this.settings);
+		this.dateFormatter.setFormat(this.settings.customDateFormat);
 
 		// add icon to the left ribbon
 		const ribbonIconEl = this.addRibbonIcon('database', 'Add new Media DB entry', () => this.createEntryWithAdvancedSearchModal());
@@ -563,6 +567,7 @@ export default class MediaDbPlugin extends Plugin {
 	async saveSettings(): Promise<void> {
 		this.mediaTypeManager.updateTemplates(this.settings);
 		this.mediaTypeManager.updateFolders(this.settings);
+		this.dateFormatter.setFormat(this.settings.customDateFormat);
 
 		await this.saveData(this.settings);
 	}

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -7,12 +7,14 @@ import PropertyMappingModelsComponent from './PropertyMappingModelsComponent.sve
 import { PropertyMapping, PropertyMappingModel, PropertyMappingOption } from './PropertyMapping';
 import { MEDIA_TYPES } from '../utils/MediaTypeManager';
 import { MediaTypeModel } from '../models/MediaTypeModel';
+import { fragWithHTML } from '../utils/Utils';
 
 export interface MediaDbPluginSettings {
 	OMDbKey: string;
 	sfwFilter: boolean;
 	useCustomYamlStringifier: boolean;
 	templates: boolean;
+	customDateFormat: string;
 
 	movieTemplate: string;
 	seriesTemplate: string;
@@ -50,6 +52,7 @@ const DEFAULT_SETTINGS: MediaDbPluginSettings = {
 	sfwFilter: true,
 	useCustomYamlStringifier: true,
 	templates: true,
+	customDateFormat: 'L',
 
 	movieTemplate: '',
 	seriesTemplate: '',
@@ -163,6 +166,23 @@ export class MediaDbSettingTab extends PluginSettingTab {
 					this.plugin.settings.templates = data;
 					this.plugin.saveSettings();
 				});
+			});
+
+		new Setting(containerEl)
+			.setName('Date format')
+			.setDesc(fragWithHTML("Your custom date format. Use <em>\'YYYY-MM-DD\'</em> for example.<br>" +
+				"For more syntax, refer to <a href='https://momentjs.com/docs/#/displaying/format/'>format reference</a>.<br>" +
+				"Your current syntax looks like this: <b><a id='dateformat-preview' style='pointer-events: none; cursor: default; text-decoration: none;'>" +
+				this.plugin.dateFormatter.getPreview() + "</a></b>"))
+			.addText(cb => {
+				cb.setPlaceholder(DEFAULT_SETTINGS.customDateFormat)
+					.setValue(this.plugin.settings.customDateFormat === DEFAULT_SETTINGS.customDateFormat ? '' : this.plugin.settings.customDateFormat)
+					.onChange(data => {
+						const newDateFormat = data ? data : DEFAULT_SETTINGS.customDateFormat;
+						this.plugin.settings.customDateFormat = newDateFormat;
+						document.getElementById('dateformat-preview').innerHTML = this.plugin.dateFormatter.getPreview(newDateFormat); // update preview
+						this.plugin.saveSettings();
+					});
 			});
 
 		containerEl.createEl('h3', { text: 'New File Location' });

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -172,7 +172,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 			.setName('Date format')
 			.setDesc(fragWithHTML("Your custom date format. Use <em>\'YYYY-MM-DD\'</em> for example.<br>" +
 				"For more syntax, refer to <a href='https://momentjs.com/docs/#/displaying/format/'>format reference</a>.<br>" +
-				"Your current syntax looks like this: <b><a id='dateformat-preview' style='pointer-events: none; cursor: default; text-decoration: none;'>" +
+				"Your current syntax looks like this: <b><a id='media-db-dateformat-preview' style='pointer-events: none; cursor: default; text-decoration: none;'>" +
 				this.plugin.dateFormatter.getPreview() + "</a></b>"))
 			.addText(cb => {
 				cb.setPlaceholder(DEFAULT_SETTINGS.customDateFormat)
@@ -180,7 +180,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 					.onChange(data => {
 						const newDateFormat = data ? data : DEFAULT_SETTINGS.customDateFormat;
 						this.plugin.settings.customDateFormat = newDateFormat;
-						document.getElementById('dateformat-preview').innerHTML = this.plugin.dateFormatter.getPreview(newDateFormat); // update preview
+						document.getElementById('media-db-dateformat-preview').textContent = this.plugin.dateFormatter.getPreview(newDateFormat); // update preview
 						this.plugin.saveSettings();
 					});
 			});

--- a/src/utils/DateFormatter.ts
+++ b/src/utils/DateFormatter.ts
@@ -1,0 +1,70 @@
+// obsidian already uses moment, so no need to package it twice!
+// import { moment } from 'obsidian'; // doesn't work for release build
+// obsidian uses a namespace-style import for moment, which ES6 doesn't allow anymore
+const obsidian = require('obsidian');
+const moment = obsidian.moment;
+
+export class DateFormatter {
+	toFormat: string;
+	localeString: string;
+
+	constructor() {
+		this.toFormat = 'YYYY-MM-DD';
+		// get locale string (e.g. en, en-gb, de, fr, etc.)
+		this.localeString = new Intl.DateTimeFormat().resolvedOptions().locale;
+	}
+
+	setFormat(format: string): void {
+		this.toFormat = format;
+	}
+
+	getPreview(format?: string): string {
+		const today = moment();
+		today.locale(this.localeString);
+
+		if (!format) {
+			format = this.toFormat;
+		}
+
+		return today.format(format);
+	}
+
+	/**
+	 * Tries to format a given date string with the currently set date format.
+	 * You can set a date format by calling `setFormat()`.
+	 *
+	 * @param dateString the date string to be formatted
+	 * @param dateFormat the current format of `dateString`. When this is `null` and the actual format of the 
+	 * given date string is not `C2822` or `ISO` format, this function will try to guess the format by using the native `Date` module.
+	 * @returns formatted date string or null if `dateString` is not a valid date
+	 */
+	format(dateString: string, dateFormat?: string): string | null {
+		if (!dateString) {
+			return null;
+		}
+
+		let date: moment.Moment;
+
+		if (!dateFormat) {
+			// reading date formats other then C2822 or ISO with moment is deprecated
+			if (this.hasMomentFormat(dateString)) {
+				// expect C2822 or ISO format
+				date = moment(dateString);
+			} else {
+				// try to read date string with native Date
+				date = moment(new Date(dateString));
+			}
+			date.locale(this.localeString); // set local locale definition for moment
+		} else {
+			date = moment(dateString, dateFormat, this.localeString);
+		}
+
+		// format date (if it is valid)
+		return date.isValid() ? date.format(this.toFormat) : null;
+	}
+
+	private hasMomentFormat(dateString: string): boolean {
+		const date = moment(dateString, true); // strict mode
+		return date.isValid();
+	}
+}

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -135,6 +135,8 @@ export function markdownTable(content: string[][]): string {
 	return table;
 }
 
+export const fragWithHTML = (html: string) => createFragment(frag => (frag.createDiv().innerHTML = html));
+
 export function dateToString(date: Date): string {
 	return `${date.getMonth() + 1}-${date.getDate()}-${date.getFullYear()}`;
 }


### PR DESCRIPTION
This adds the option to set a custom date format, like requested in #78 by @iznaut.

I added a `DateFormatter` class, which gets used in the `APIModel`s to format date strings. I also looked up what type of date formats are used by the various APIs, and saved them as variables called `apiDateFormat`. This makes the date formatting more robust, because you don't have to guess the actual date formats.

The `DateFormatter` holds the currently set custom date format. This gets updated in the `main` - by calling the `setFormat()` function of `DateFormatter` - when the user changes the custom date format in the settings tab.

For the settings tab, I added a text field where the user can input a custom date format string. The settings also shows a preview of what the current format will look like.
![image](https://github.com/mProjectsCode/obsidian-media-db-plugin/assets/20826616/9151408e-fbd5-4add-b2d1-64255e784a50)

For the actual date formatting the `DateFormatter` uses `moment.js`. Which is also used and **exported** by `obsidian` itself. But I had some trouble importing it. With `esModuleInterop` set in the compiler config, the type script compiler doesn't like that `obsidian` imports `moment` with a namespace-style import (which is also not compliant with ES6 module spec) like this:
``` ts
// obsidian.ts
import * as Moment from 'moment';
export const moment: typeof Moment;
```
So when running `npm run build` the following always results in compiler errors complaining about the namespace-style import of `moment` in `obsidian.ts`:
``` ts
// DateFormatter.ts
import { 'moment' } from 'obsidian';
```
I eventually got it to work with:
``` ts
// DateFormatter.ts
const obsidian = require('obsidian');
const moment = obsidian.moment;
```
I don't know if this is a good way to import it though.