### PR TITLE
Add index operator for arrays when templating

### DIFF
--- a/src/utils/MediaTypeManager.ts
+++ b/src/utils/MediaTypeManager.ts
@@ -65,7 +65,8 @@ export class MediaTypeManager {
 	}
 
 	getFileName(mediaTypeModel: MediaTypeModel): string {
-		return replaceTags(this.mediaFileNameTemplateMap.get(mediaTypeModel.getMediaType()), mediaTypeModel);
+		// Ignore undefined tags since some search APIs do not return all properties in the model and produce clean file names even if errors occur
+		return replaceTags(this.mediaFileNameTemplateMap.get(mediaTypeModel.getMediaType()), mediaTypeModel, true);
 	}
 
 	async getTemplate(mediaTypeModel: MediaTypeModel, app: App): Promise<string> {

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -64,6 +64,16 @@ function replaceTag(match: string, mediaTypeModel: MediaTypeModel): string {
 				return '{{ INVALID TEMPLATE TAG - operator ENUM is only applicable on an array }}';
 			}
 			return obj.join(', ');
+		} else if (operator === 'FIRST') {
+			if (!Array.isArray(obj)) {
+				return '{{ INVALID TEMPLATE TAG - operator FIRST is only applicable on an array }}';
+			}
+			return obj[0];
+		} else if (operator === 'LAST') {
+			if (!Array.isArray(obj)) {
+				return '{{ INVALID TEMPLATE TAG - operator LAST is only applicable on an array }}';
+			}
+			return obj[obj.length - 1];
 		}
 
 		return `{{ INVALID TEMPLATE TAG - unknown operator ${operator} }}`;

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -22,11 +22,11 @@ export function replaceIllegalFileNameCharactersInString(string: string): string
 	return string.replace(/[\\,#%&{}/*<>$"@.?]*/g, '').replace(/:+/g, ' -');
 }
 
-export function replaceTags(template: string, mediaTypeModel: MediaTypeModel): string {
-	return template.replace(new RegExp('{{.*?}}', 'g'), (match: string) => replaceTag(match, mediaTypeModel));
+export function replaceTags(template: string, mediaTypeModel: MediaTypeModel, ignoreUndefined: boolean = false): string {
+	return template.replace(new RegExp('{{.*?}}', 'g'), (match: string) => replaceTag(match, mediaTypeModel, ignoreUndefined));
 }
 
-function replaceTag(match: string, mediaTypeModel: MediaTypeModel): string {
+function replaceTag(match: string, mediaTypeModel: MediaTypeModel, ignoreUndefined: boolean): string {
 	let tag = match;
 	tag = tag.substring(2);
 	tag = tag.substring(0, tag.length - 2);
@@ -39,7 +39,7 @@ function replaceTag(match: string, mediaTypeModel: MediaTypeModel): string {
 		const obj = traverseMetaData(path, mediaTypeModel);
 
 		if (obj === undefined) {
-			return '{{ INVALID TEMPLATE TAG - object undefined }}';
+			return ignoreUndefined ? '' : '{{ INVALID TEMPLATE TAG - object undefined }}';
 		}
 
 		return obj;
@@ -51,7 +51,7 @@ function replaceTag(match: string, mediaTypeModel: MediaTypeModel): string {
 		const obj = traverseMetaData(path, mediaTypeModel);
 
 		if (obj === undefined) {
-			return '{{ INVALID TEMPLATE TAG - object undefined }}';
+			return ignoreUndefined ? '' : '{{ INVALID TEMPLATE TAG - object undefined }}';
 		}
 
 		if (operator === 'LIST') {


### PR DESCRIPTION
Closes #127 

The `ignoreUndefined` option in `replaceTags` is required to be true in `getFileName` due to some search APIs not returning all data that is specified in the model. That means when you used for example the `director` tag in the file name, the search would look like below:

![image](https://github.com/mProjectsCode/obsidian-media-db-plugin/assets/41587072/c41eda6a-2953-46d7-8922-c644e0151486)
