### PR TITLE
Embed Image links 

### DIFF
--- a/src/api/apis/MALAPI.ts
+++ b/src/api/apis/MALAPI.ts
@@ -116,7 +116,7 @@ export class MALAPI extends APIModel {
 				duration: result.duration ?? 'unknown',
 				onlineRating: result.score ?? 0,
 				actors: [],
-				image: result.images?.jpg?.image_url ?? '',
+				image: result.images?.jpg?.image_url ? `![](${result.images?.jpg?.image_url})` : '',
 
 				released: true,
 				premiere: this.plugin.dateFormatter.format(result.aired?.from, this.apiDateFormat) ?? 'unknown',
@@ -150,7 +150,7 @@ export class MALAPI extends APIModel {
 				duration: result.duration ?? 'unknown',
 				onlineRating: result.score ?? 0,
 				actors: [],
-				image: result.images?.jpg?.image_url ?? '',
+				image: result.images?.jpg?.image_url ? `![](${result.images?.jpg?.image_url})` : '',
 
 				released: true,
 				premiere: this.plugin.dateFormatter.format(result.aired?.from, this.apiDateFormat) ?? 'unknown',
@@ -181,7 +181,7 @@ export class MALAPI extends APIModel {
 				duration: result.duration ?? 'unknown',
 				onlineRating: result.score ?? 0,
 				streamingServices: result.streaming?.map((x: any) => x.name) ?? [],
-				image: result.images?.jpg?.image_url ?? '',
+				image: result.images?.jpg?.image_url ? `![](${result.images?.jpg?.image_url})` : '',
 
 				released: true,
 				airedFrom: this.plugin.dateFormatter.format(result.aired?.from, this.apiDateFormat) ?? 'unknown',

--- a/src/api/apis/OMDbAPI.ts
+++ b/src/api/apis/OMDbAPI.ts
@@ -142,7 +142,7 @@ export class OMDbAPI extends APIModel {
 				duration: result.Runtime ?? 'unknown',
 				onlineRating: Number.parseFloat(result.imdbRating ?? 0),
 				actors: result.Actors?.split(', ') ?? [],
-				image: result.Poster ?? '',
+				image: result.Poster ? `"![](${result.Poster})"` : '',
 
 				released: true,
 				streamingServices: [],
@@ -174,7 +174,7 @@ export class OMDbAPI extends APIModel {
 				duration: result.Runtime ?? 'unknown',
 				onlineRating: Number.parseFloat(result.imdbRating ?? 0),
 				actors: result.Actors?.split(', ') ?? [],
-				image: result.Poster ?? '',
+				image: result.Poster ? `![](${result.Poster})` : '',
 
 				released: true,
 				streamingServices: [],
@@ -204,7 +204,7 @@ export class OMDbAPI extends APIModel {
 				publishers: [],
 				genres: result.Genre?.split(', ') ?? [],
 				onlineRating: Number.parseFloat(result.imdbRating ?? 0),
-				image: result.Poster ?? '',
+				image: result.Poster ? `![](${result.Poster})` : '',
 
 				released: true,
 				releaseDate: this.plugin.dateFormatter.format(result.Released, this.apiDateFormat) ?? 'unknown',


### PR DESCRIPTION
Changed the way the image link are outputted so that they are embed ready instead of it just being a web link to the image

![image](https://github.com/mProjectsCode/obsidian-media-db-plugin/assets/43733760/e341e50d-42fb-46f8-a729-72fdc8b68c77)
![image](https://github.com/mProjectsCode/obsidian-media-db-plugin/assets/43733760/041519e7-bfa7-4996-8973-699654216800)

this allows dataview to work  without any extra steps 

 
![image](https://github.com/mProjectsCode/obsidian-media-db-plugin/assets/43733760/d2da3b88-664a-4814-8347-89f29588a01f)
![image](https://github.com/mProjectsCode/obsidian-media-db-plugin/assets/43733760/330fbff4-8720-4dda-a18d-24ee3f902c30)
![image](https://github.com/mProjectsCode/obsidian-media-db-plugin/assets/43733760/1d9eb911-3083-48d8-8b85-c46ee7ff5ae5)
![image](https://github.com/mProjectsCode/obsidian-media-db-plugin/assets/43733760/2e3b1c8c-782c-4021-b6c0-67cc515d4a53)
