### PR TITLE
Copywriting improvements to match official guidelines

### DIFF
--- a/src/settings/PropertyMappingModelComponent.svelte
+++ b/src/settings/PropertyMappingModelComponent.svelte
@@ -24,7 +24,7 @@
 					<pre class="media-db-plugin-property-mapping-element-property-name"><code>{property.property}</code></pre>
 				</div>
 				{#if property.locked}
-					<div class="media-db-plugin-property-binding-text">property can not be remapped</div>
+					<div class="media-db-plugin-property-binding-text">property cannot be remapped</div>
 				{:else}
 					<select class="dropdown" bind:value={property.mapping}>
 						{#each propertyMappingOptions as remappingOption}

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -347,7 +347,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 		// 		});
 		// 	});
 
-		containerEl.createEl('h3', { text: 'New file location' });
+		new Setting(containerEl).setName('New file location').setHeading();
 		// region new file location
 		new Setting(containerEl)
 			.setName('Movie folder')
@@ -453,7 +453,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 			});
 		// endregion
 
-		containerEl.createEl('h3', { text: 'Template settings' });
+		new Setting(containerEl).setName('Template settings').setHeading();
 		// region templates
 		new Setting(containerEl)
 			.setName('Movie template')
@@ -560,7 +560,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 			});
 		// endregion
 
-		containerEl.createEl('h3', { text: 'File name settings' });
+		new Setting(containerEl).setName('File name settings').setHeading();
 		// region file name templates
 		new Setting(containerEl)
 			.setName('Movie file name template')
@@ -661,19 +661,16 @@ export class MediaDbSettingTab extends PluginSettingTab {
 
 		// region Property Mappings
 		if (this.plugin.settings.useDefaultFrontMatter) {
-			containerEl.createEl('h3', { text: 'Property mappings' });
+			new Setting(containerEl).setName('Property mappings').setHeading();
 
 			const propertyMappingExplanation = containerEl.createEl('div');
 			propertyMappingExplanation.innerHTML = `
-		<p>Remap the metadata fields of newly created media DB entries.</p>
-		<p>
-			The options are:
-			<ul>
-				<li>"default": does no remapping and keeps the metadata field as it is</li>
-				<li>"remap": renames the metadata field to what ever you specify</li>
-				<li>"remove": removes the metadata field entirely</li>
-			</ul>
-		</p>
+		<p>Choose how metadata fields are mapped to property names. The options are:</p>
+		<ul>
+			<li><strong>default</strong>: keep the original name.</li>
+			<li><strong>remap</strong>: rename the property.</li>
+			<li><strong>remove</strong>: remove the property entirely.</li>
+		</ul>
 		<p>
 			Don't forget to save your changes using the save button for each individual category.
 		</p>`;

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -179,8 +179,6 @@ export class MediaDbSettingTab extends PluginSettingTab {
 
 		containerEl.empty();
 
-		containerEl.createEl('h2', { text: 'Media DB Plugin Settings' });
-
 		new Setting(containerEl)
 			.setName('OMDb API key')
 			.setDesc('API key for "www.omdbapi.com".')
@@ -281,7 +279,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 				});
 			});
 
-		// containerEl.createEl('h3', { text: 'APIs Per Media Type' });
+		// containerEl.createEl('h3', { text: 'APIs per media type' });
 		// containerEl.createEl('h5', { text: 'Movies' });
 		// new Setting(containerEl)
 		// 	.setName('OMDb API')
@@ -349,10 +347,10 @@ export class MediaDbSettingTab extends PluginSettingTab {
 		// 		});
 		// 	});
 
-		containerEl.createEl('h3', { text: 'New File Location' });
+		containerEl.createEl('h3', { text: 'New file location' });
 		// region new file location
 		new Setting(containerEl)
-			.setName('Movie Folder')
+			.setName('Movie folder')
 			.setDesc('Where newly imported movies should be placed.')
 			.addSearch(cb => {
 				new FolderSuggest(this.app, cb.inputEl);
@@ -365,7 +363,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName('Series Folder')
+			.setName('Series folder')
 			.setDesc('Where newly imported series should be placed.')
 			.addSearch(cb => {
 				new FolderSuggest(this.app, cb.inputEl);
@@ -378,7 +376,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName('Manga Folder')
+			.setName('Manga folder')
 			.setDesc('Where newly imported manga should be placed.')
 			.addSearch(cb => {
 				new FolderSuggest(this.app, cb.inputEl);
@@ -391,7 +389,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName('Game Folder')
+			.setName('Game folder')
 			.setDesc('Where newly imported games should be placed.')
 			.addSearch(cb => {
 				new FolderSuggest(this.app, cb.inputEl);
@@ -404,7 +402,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName('Wiki Folder')
+			.setName('Wiki folder')
 			.setDesc('Where newly imported wiki articles should be placed.')
 			.addSearch(cb => {
 				new FolderSuggest(this.app, cb.inputEl);
@@ -417,7 +415,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName('Music Folder')
+			.setName('Music folder')
 			.setDesc('Where newly imported music should be placed.')
 			.addSearch(cb => {
 				new FolderSuggest(this.app, cb.inputEl);
@@ -430,7 +428,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName('Board Game Folder')
+			.setName('Board game folder')
 			.setDesc('Where newly imported board games should be places.')
 			.addSearch(cb => {
 				new FolderSuggest(this.app, cb.inputEl);
@@ -442,7 +440,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 					});
 			});
 		new Setting(containerEl)
-			.setName('Book Folder')
+			.setName('Book folder')
 			.setDesc('Where newly imported books should be placed.')
 			.addSearch(cb => {
 				new FolderSuggest(this.app, cb.inputEl);
@@ -455,7 +453,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 			});
 		// endregion
 
-		containerEl.createEl('h3', { text: 'Template Settings' });
+		containerEl.createEl('h3', { text: 'Template settings' });
 		// region templates
 		new Setting(containerEl)
 			.setName('Movie template')
@@ -523,7 +521,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName('Music Release template')
+			.setName('Music release template')
 			.setDesc('Template file to be used when creating a new note for a music release.')
 			.addSearch(cb => {
 				new FileSuggest(this.app, cb.inputEl);
@@ -536,7 +534,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName('Board Game template')
+			.setName('Board game template')
 			.setDesc('Template file to be used when creating a new note for a boardgame.')
 			.addSearch(cb => {
 				new FileSuggest(this.app, cb.inputEl);
@@ -562,7 +560,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 			});
 		// endregion
 
-		containerEl.createEl('h3', { text: 'File Name Settings' });
+		containerEl.createEl('h3', { text: 'File name settings' });
 		// region file name templates
 		new Setting(containerEl)
 			.setName('Movie file name template')
@@ -625,7 +623,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName('Music Release file name template')
+			.setName('Music release file name template')
 			.setDesc('Template for the file name used when creating a new note for a music release.')
 			.addText(cb => {
 				cb.setPlaceholder(`Example: ${DEFAULT_SETTINGS.musicReleaseFileNameTemplate}`)
@@ -637,7 +635,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName('Board Game file name template')
+			.setName('Board game file name template')
 			.setDesc('Template for the file name used when creating a new note for a boardgame.')
 			.addText(cb => {
 				cb.setPlaceholder(`Example: ${DEFAULT_SETTINGS.boardgameFileNameTemplate}`)
@@ -663,18 +661,18 @@ export class MediaDbSettingTab extends PluginSettingTab {
 
 		// region Property Mappings
 		if (this.plugin.settings.useDefaultFrontMatter) {
-			containerEl.createEl('h3', { text: 'Property Mappings' });
+			containerEl.createEl('h3', { text: 'Property mappings' });
 
 			const propertyMappingExplanation = containerEl.createEl('div');
 			propertyMappingExplanation.innerHTML = `
-		<p>Allow you to remap the metadata fields of newly created media db entries.</p>
+		<p>Remap the metadata fields of newly created media DB entries.</p>
 		<p>
-			The different options are:
-			<lu>
+			The options are:
+			<ul>
 				<li>"default": does no remapping and keeps the metadata field as it is</li>
 				<li>"remap": renames the metadata field to what ever you specify</li>
 				<li>"remove": removes the metadata field entirely</li>
-			</lu>
+			</ul>
 		</p>
 		<p>
 			Don't forget to save your changes using the save button for each individual category.
@@ -696,7 +694,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 						}
 
 						this.plugin.settings.propertyMappingModels = propertyMappingModels;
-						new Notice(`MDB: Property Mappings for ${model.type} saved successfully.`);
+						new Notice(`MDB: Property mappings for ${model.type} saved successfully.`);
 						void this.plugin.saveSettings();
 					},
 				},


### PR DESCRIPTION
This PR updates Media DB settings to match [Obsidian plugin guidelines](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#UI+text) for UI text.

- [x] [Sentence case](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Use+sentence+case+in+UI)
- [x] [Remove top level heading](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Only+use+headings+under+settings+if+you+have+more+than+one+section.)
- [x] [use setHeading](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Use+%60setHeading%60+instead+of+a+%60%3Ch1%3E%60%2C+%60%3Ch2%3E%60) instead of `h3`
- [x] Simplify copy for the mappings section