### PR TITLE
Add the VNDB API as a `Game` source for visual novels

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Now you select the result you want and the plugin will cast it's magic and creat
 | [Steam](https://store.steampowered.com/)             | The Steam API offers information on all steam games.                                              | games                                                 | No                                                                           | 10000 per day                                                                                                                                                 | No                 |
 | [Open Library](https://openlibrary.org)              | The OpenLibrary API offers metadata for books                                                     | books                                                 | No                                                                           | Cover access is rate-limited when not using CoverID or OLID by max 100 requests/IP every 5 minutes. This plugin uses OLID so there shouldn't be a rate limit. | No                 |
 | [Moby Games](https://www.mobygames.com)              | The Moby Games API offers metadata for games for all platforms                                    | games                                                 | Yes, by making an account [here](https://www.mobygames.com/user/register/)   | API requests are limited to 360 per hour (one every ten seconds). In addition, requests should be made no more frequently than one per second.                | No                 |
+| [VNDB](https://vndb.org/)                            | The VNDB API offers metadata for visual novels                                                    | games                                                 | No                                                                           | 200 requests per 5 minutes                                                                                                                                    | Yes                |
 
 #### Notes
 
@@ -156,6 +157,9 @@ Now you select the result you want and the plugin will cast it's magic and creat
 -   [Moby Games](https://www.mobygames.com)
     -   you can find this ID in the URL
         -   e.g. for "Bioshock 2" the URL looks like this `https://www.mobygames.com/game/45089/bioshock-2/` so the ID is `45089`
+-   [VNDB](https://vndb.org/)
+    -   Located in the novel's VNDB URL path
+        -   e.g. The ID for [Katawa Shoujo](https://vndb.org/v945) (`https://vndb.org/v945`) is `v945`
 
 ### Problems, unexpected behavior or improvement suggestions?
 

--- a/src/api/apis/VNDBAPI.ts
+++ b/src/api/apis/VNDBAPI.ts
@@ -113,8 +113,15 @@ export class VNDBAPI extends APIModel {
 	async searchByTitle(title: string): Promise<MediaTypeModel[]> {
 		console.log(`MDB | api "${this.apiName}" queried by Title`);
 
+		// prettier-ignore
 		const vnData = await this.postVNQuery(`{
-			"filters": ["search", "=", "${title}"],
+			"filters": ["and", ${!this.plugin.settings.sfwFilter ? `` :
+				`["release", "!=", ["and",
+					["official", "=", "1"],
+					["has_ero", "=", "1"]
+				]],`}
+				["search", "=", "${title}"]
+			],
 			"fields": "title, titles{title, lang}, released",
 			"sort": "searchrank",
 			"results": 20

--- a/src/api/apis/VNDBAPI.ts
+++ b/src/api/apis/VNDBAPI.ts
@@ -1,0 +1,195 @@
+import { APIModel } from '../APIModel';
+import { MediaTypeModel } from '../../models/MediaTypeModel';
+import MediaDbPlugin from '../../main';
+import { GameModel } from '../../models/GameModel';
+import { requestUrl } from 'obsidian';
+import { MediaType } from '../../utils/MediaType';
+
+/**
+ * A partial `POST /vn` response payload; desired fields should be listed in the request body.
+ */
+interface VNJSONResponse {
+	more: boolean;
+	results: [
+		{
+			id: string;
+			title: string;
+			titles: [
+				{
+					title: string;
+					lang: string;
+				},
+			];
+			devstatus: 0 | 1 | 2; // Released | In-development | Cancelled
+			released: string | 'TBA' | null;
+			image: {
+				url: string;
+			} | null;
+			rating: number | null;
+			tags: [
+				{
+					id: string;
+					name: string;
+					category: 'cont' | 'ero' | 'tech';
+					rating: number;
+					spoiler: 0 | 1 | 2; // None | Minor | Major
+				},
+			];
+			developers: [
+				{
+					id: string;
+					name: string;
+				},
+			];
+		},
+	];
+}
+
+/**
+ * A partial `POST /release` response payload; desired fields should be listed in the request body.
+ */
+interface ReleaseJSONResponse {
+	more: boolean;
+	results: [
+		{
+			id: string;
+			producers: [
+				{
+					id: string;
+					name: string;
+					developer: boolean;
+					publisher: boolean;
+				},
+			];
+		},
+	];
+}
+
+export class VNDBAPI extends APIModel {
+	plugin: MediaDbPlugin;
+	apiDateFormat: string = 'YYYY-MM-DD'; // Can also return YYYY-MM or YYYY
+
+	constructor(plugin: MediaDbPlugin) {
+		super();
+
+		this.plugin = plugin;
+		this.apiName = 'VNDB API';
+		this.apiDescription = 'A free API for visual novels.';
+		this.apiUrl = 'https://api.vndb.org/kana';
+		this.types = [MediaType.Game];
+	}
+
+	postVNQuery = (body: string): Promise<VNJSONResponse> => this.postQuery('/vn', body);
+	postReleaseQuery = (body: string): Promise<ReleaseJSONResponse> => this.postQuery('/release', body);
+	async postQuery(endpoint: string, body: string): Promise<any> {
+		const fetchData = await requestUrl({
+			url: `${this.apiUrl}${endpoint}`,
+			method: 'POST',
+			contentType: 'application/json',
+			body: body,
+			throw: false,
+		});
+
+		if (fetchData.status !== 200) {
+			switch (fetchData.status) {
+				case 400:
+					throw Error(`MDB | Invalid request body or query [${fetchData.text}].`);
+				case 404:
+					throw Error(`MDB | Invalid API path or HTTP method.`);
+				case 429:
+					throw Error(`MDB | Throttled.`);
+				case 500:
+					throw Error(`MDB | VNDB server error.`);
+				case 502:
+					throw Error(`MDB | VNDB server is down.`);
+				default:
+					throw Error(`MDB | Received status code ${fetchData.status} from ${this.apiName}.`);
+			}
+		}
+
+		return fetchData.json;
+	}
+
+	async searchByTitle(title: string): Promise<MediaTypeModel[]> {
+		console.log(`MDB | api "${this.apiName}" queried by Title`);
+
+		const vnData = await this.postVNQuery(`{
+			"filters": ["search", "=", "${title}"],
+			"fields": "title, titles{title, lang}, released",
+			"sort": "searchrank",
+			"results": 20
+		}`);
+
+		const ret: MediaTypeModel[] = [];
+		for (const vn of vnData.results) {
+			ret.push(
+				new GameModel({
+					type: MediaType.Game,
+					title: vn.title,
+					englishTitle: vn.titles.find(t => t.lang === 'en')?.title ?? vn.title,
+					year: vn.released && vn.released !== 'TBA' ? new Date(vn.released).getFullYear().toString() : 'TBA',
+					dataSource: this.apiName,
+					id: vn.id,
+				} as GameModel),
+			);
+		}
+
+		return ret;
+	}
+
+	async getById(id: string): Promise<MediaTypeModel> {
+		console.log(`MDB | api "${this.apiName}" queried by ID`);
+
+		const vnData = await this.postVNQuery(`{
+			"filters": ["id", "=", "${id}"],
+			"fields": "title, titles{title, lang}, devstatus, released, image{url}, rating, tags{name, category, rating, spoiler}, developers{name}"
+		}`);
+
+		if (vnData.results.length !== 1) throw Error(`MDB | Expected 1 result from query, got ${vnData.results.length}.`);
+		const vn = vnData.results[0];
+
+		const releaseData = await this.postReleaseQuery(`{
+			"filters": ["and",
+				["vn", "=",
+					["id", "=", "${id}"]
+				],
+				["official", "=", 1],
+				["patch", "!=", 1]
+			],
+			"fields": "producers.name, producers.publisher, producers.developer",
+			"results": 100
+		}`);
+
+		return new GameModel({
+			type: MediaType.Game,
+			title: vn.title,
+			englishTitle: vn.titles.find(t => t.lang === 'en')?.title ?? vn.title,
+			year: vn.released && vn.released !== 'TBA' ? new Date(vn.released).getFullYear().toString() : 'TBA',
+			dataSource: this.apiName,
+			url: `https://vndb.org/${vn.id}`,
+			id: vn.id,
+
+			developers: vn.developers.map(d => d.name),
+			publishers: releaseData.results
+				.flatMap(r => r.producers)
+				.filter(p => p.publisher)
+				.sort((p1, p2) => Number(p2.developer) - Number(p1.developer)) // Place developer-publishers first in publisher list
+				.map(p => p.name)
+				.unique(),
+			genres: vn.tags
+				.filter(t => t.category === 'cont' && t.spoiler === 0 && t.rating >= 2)
+				.sort((t1, t2) => t2.rating - t1.rating)
+				.map(t => t.name),
+			onlineRating: vn.rating ?? NaN,
+			image: vn.image?.url,
+
+			released: vn.devstatus === 0,
+			releaseDate: this.plugin.dateFormatter.format(vn.released, this.apiDateFormat),
+
+			userData: {
+				played: false,
+				personalRating: 0,
+			},
+		} as GameModel);
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import { SteamAPI } from './api/apis/SteamAPI';
 import { BoardGameGeekAPI } from './api/apis/BoardGameGeekAPI';
 import { OpenLibraryAPI } from './api/apis/OpenLibraryAPI';
 import { MobyGamesAPI } from './api/apis/MobyGamesAPI';
+import { VNDBAPI } from './api/apis/VNDBAPI';
 import { PropertyMapper } from './settings/PropertyMapper';
 import { MediaDbFolderImportModal } from './modals/MediaDbFolderImportModal';
 import { PropertyMapping, PropertyMappingModel } from './settings/PropertyMapping';
@@ -58,6 +59,7 @@ export default class MediaDbPlugin extends Plugin {
 		this.apiManager.registerAPI(new BoardGameGeekAPI(this));
 		this.apiManager.registerAPI(new OpenLibraryAPI(this));
 		this.apiManager.registerAPI(new MobyGamesAPI(this));
+		this.apiManager.registerAPI(new VNDBAPI(this));
 		// this.apiManager.registerAPI(new LocGovAPI(this)); // TODO: parse data
 
 		this.mediaTypeManager = new MediaTypeManager();


### PR DESCRIPTION
This adds [VNDB](https://vndb.org) as a new API source for visual novels. The API documentation and endpoint can be found [here](https://api.vndb.org/kana). All `GameModel` fields are populated, and the SFW flag is supported[^1].

Spurred primarily by #164, and Steam typically having a blind spot for visual novels.

Some implementation details for RFC:
- I've set the number of results requested per search query to 20 (from the default 10), which I believe matches our other sources.
- The `GameModel.genres` field is populated with `content` tags that have been scored as [significant](https://vndb.org/d10#2.1), and aren't spoilers. This is my interpretation of what most people will actually want, but we can always spit out every tag.
- Because VNDB can return a partial release date (e.g. `2024-10`), the plugin `dateFormatter` will end up coercing these dates to an erroneous specificity (e.g. `01-10-2024`). This is relatively minor.

[^1]: VN entries with *any* official NSFW release are filtered out.