### PR TITLE
Added support for giant bomb api and modified the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ Now you select the result you want and the plugin will cast it's magic and creat
 | [Wikipedia](https://en.wikipedia.org/wiki/Main_Page) | The Wikipedia API allows access to all Wikipedia articles.                                        | wiki articles                                         | No                                                                           | None                                                                                                                                                          | No                 |
 | [Steam](https://store.steampowered.com/)             | The Steam API offers information on all steam games.                                              | games                                                 | No                                                                           | 10000 per day                                                                                                                                                 | No                 |
 | [Open Library](https://openlibrary.org)              | The OpenLibrary API offers metadata for books                                                     | books                                                 | No                                                                           | Cover access is rate-limited when not using CoverID or OLID by max 100 requests/IP every 5 minutes. This plugin uses OLID so there shouldn't be a rate limit. | No                 |
-| [Moby Games](https://www.mobygames.com)              | The Moby Games API offers metadata for games for all platforms                                    | games                                                 | Yes, by making an account [here](https://www.mobygames.com/user/register/)   | API requests are limited to 360 per hour (one every ten seconds). In addition, requests should be made no more frequently than one per second.                | No                 |
+| [Moby Games](https://www.mobygames.com)              | The Moby Games API offers metadata for games for all platforms                                    | games                                                 | Yes, by making an account [here](https://www.mobygames.com/user/register/). NOTE: As of September 2024 the API key  is no longer free so consider using Giant Bomb or steam instead   | API requests are limited to 360 per hour (one every ten seconds). In addition, requests should be made no more frequently than one per second.                | No                 |
+| [Giant Bomb](https://www.giantbomb.com)              | The Giant Bomb API offers metadata for games for all platforms                                    | games                                                 | Yes, by making an account [here](https://www.giantbomb.com/login-signup/)   | API requests are limited to 200 requests per resource, per hour. In addition, they implement velocity detection to prevent malicious use. If too many requests are made per second, you may receive temporary blocks to resources.                | No                 |
 
 #### Notes
 
@@ -156,6 +157,9 @@ Now you select the result you want and the plugin will cast it's magic and creat
 -   [Moby Games](https://www.mobygames.com)
     -   you can find this ID in the URL
         -   e.g. for "Bioshock 2" the URL looks like this `https://www.mobygames.com/game/45089/bioshock-2/` so the ID is `45089`
+-   [Giant Bomb](https://www.giantbomb.com)
+    -   you can find this ID in the URL
+        -   e.g. for "Dota 2" the URL looks like this `https://www.giantbomb.com/dota-2/3030-32887/` so the ID is `3030-32887`
 
 ### Problems, unexpected behavior or improvement suggestions?
 

--- a/src/api/apis/GiantBombAPI.ts
+++ b/src/api/apis/GiantBombAPI.ts
@@ -1,0 +1,109 @@
+import { APIModel } from '../APIModel';
+import { MediaTypeModel } from '../../models/MediaTypeModel';
+import MediaDbPlugin from '../../main';
+import { GameModel } from '../../models/GameModel';
+import { requestUrl } from 'obsidian';
+import { MediaType } from '../../utils/MediaType';
+
+export class GiantBombAPI extends APIModel {
+	plugin: MediaDbPlugin;
+	apiDateFormat: string = 'YYYY-MM-DD';
+
+	constructor(plugin: MediaDbPlugin) {
+		super();
+
+		this.plugin = plugin;
+		this.apiName = 'GiantBombAPI';
+		this.apiDescription = 'A free API for games.';
+		this.apiUrl = 'https://www.giantbomb.com/api';
+		this.types = [MediaType.Game];
+	}
+	async searchByTitle(title: string): Promise<MediaTypeModel[]> {
+		console.log(`MDB | api "${this.apiName}" queried by Title`);
+
+		if (!this.plugin.settings.GiantBombKey) {
+			throw Error(`MDB | API key for ${this.apiName} missing.`);
+		}
+
+		const searchUrl = `${this.apiUrl}/games?api_key=${this.plugin.settings.GiantBombKey}&filter=name:${encodeURIComponent(title)}&format=json`;
+		const fetchData = await requestUrl({
+			url: searchUrl,
+		});
+
+		// console.debug(fetchData);
+
+		if (fetchData.status === 401) {
+			throw Error(`MDB | Authentication for ${this.apiName} failed. Check the API key.`);
+		}
+		if (fetchData.status === 429) {
+			throw Error(`MDB | Too many requests for ${this.apiName}, you've exceeded your API quota.`);
+		}
+		if (fetchData.status !== 200) {
+			throw Error(`MDB | Received status code ${fetchData.status} from ${this.apiName}.`);
+		}
+
+		const data = await fetchData.json;
+		// console.debug(data);
+		const ret: MediaTypeModel[] = [];
+		for (const result of data.results) {
+			ret.push(
+				new GameModel({
+					type: MediaType.Game,
+					title: result.name,
+					englishTitle: result.name,
+					year: new Date(result.original_release_date).getFullYear().toString(),
+					dataSource: this.apiName,
+					id: result.guid,
+				} as GameModel),
+			);
+		}
+
+		return ret;
+	}
+
+	async getById(id: string): Promise<MediaTypeModel> {
+		console.log(`MDB | api "${this.apiName}" queried by ID`);
+
+		if (!this.plugin.settings.GiantBombKey) {
+			throw Error(`MDB | API key for ${this.apiName} missing.`);
+		}
+
+		const searchUrl = `${this.apiUrl}/game/${encodeURIComponent(id)}/?api_key=${this.plugin.settings.GiantBombKey}&format=json`;
+		const fetchData = await requestUrl({
+			url: searchUrl,
+		});
+		console.debug(fetchData);
+
+		if (fetchData.status !== 200) {
+			throw Error(`MDB | Received status code ${fetchData.status} from ${this.apiName}.`);
+		}
+
+		const data = await fetchData.json;
+		// console.debug(data);
+		const result = data.results;
+
+		return new GameModel({
+			type: MediaType.Game,
+			title: result.name,
+			englishTitle: result.name,
+			year: new Date(result.original_release_date).getFullYear().toString(),
+			dataSource: this.apiName,
+			url: result.site_detail_url,
+			id: result.guid,
+			developers: result.developers?.map((x: any) => x.name) ?? [],
+			publishers: result.publishers?.map((x: any) => x.name) ?? [],
+			genres: result.genres?.map((x: any) => x.name) ?? [],
+			onlineRating: 0,
+			image: result.image?.super_url ?? '',
+
+			released: true,
+			releaseDate: result.original_release_date ?? 'unknown',
+
+			userData: {
+				played: false,
+
+				personalRating: 0,
+			},
+		} as GameModel);
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import { SteamAPI } from './api/apis/SteamAPI';
 import { BoardGameGeekAPI } from './api/apis/BoardGameGeekAPI';
 import { OpenLibraryAPI } from './api/apis/OpenLibraryAPI';
 import { MobyGamesAPI } from './api/apis/MobyGamesAPI';
+import { GiantBombAPI } from './api/apis/GiantBombAPI';
 import { PropertyMapper } from './settings/PropertyMapper';
 import { MediaDbFolderImportModal } from './modals/MediaDbFolderImportModal';
 import { PropertyMapping, PropertyMappingModel } from './settings/PropertyMapping';
@@ -58,6 +59,7 @@ export default class MediaDbPlugin extends Plugin {
 		this.apiManager.registerAPI(new BoardGameGeekAPI(this));
 		this.apiManager.registerAPI(new OpenLibraryAPI(this));
 		this.apiManager.registerAPI(new MobyGamesAPI(this));
+		this.apiManager.registerAPI(new GiantBombAPI(this));
 		// this.apiManager.registerAPI(new LocGovAPI(this)); // TODO: parse data
 
 		this.mediaTypeManager = new MediaTypeManager();

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -12,6 +12,7 @@ import { fragWithHTML } from '../utils/Utils';
 export interface MediaDbPluginSettings {
 	OMDbKey: string;
 	MobyGamesKey: string;
+	GiantBombKey: string;
 	sfwFilter: boolean;
 	templates: boolean;
 	customDateFormat: string;
@@ -78,6 +79,7 @@ export interface MediaDbPluginSettings {
 const DEFAULT_SETTINGS: MediaDbPluginSettings = {
 	OMDbKey: '',
 	MobyGamesKey: '',
+	GiantBombKey: '',
 	sfwFilter: true,
 	templates: true,
 	customDateFormat: 'L',
@@ -191,7 +193,7 @@ export class MediaDbSettingTab extends PluginSettingTab {
 					});
 			});
 
-		new Setting(containerEl)
+			new Setting(containerEl)
 			.setName('Moby Games key')
 			.setDesc('API key for "www.mobygames.com".')
 			.addText(cb => {
@@ -199,6 +201,18 @@ export class MediaDbSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.MobyGamesKey)
 					.onChange(data => {
 						this.plugin.settings.MobyGamesKey = data;
+						void this.plugin.saveSettings();
+					});
+			});
+
+			new Setting(containerEl)
+			.setName('Giant Bomb Key')
+			.setDesc('API key for "www.giantbomb.com".')
+			.addText(cb => {
+				cb.setPlaceholder('API key')
+					.setValue(this.plugin.settings.GiantBombKey)
+					.onChange(data => {
+						this.plugin.settings.GiantBombKey = data;
 						void this.plugin.saveSettings();
 					});
 			});


### PR DESCRIPTION
This is to replace mobygames for future users that don't yet have an API key since it is now no longer free, per #164. I added a note in the readme about it but mobygames can stay in the plugin for existing users since they're currently unaffected.

As this is another api that requires authentication it should probably only be added together with #161 so users can still use unauthenticated apis like steam.