### PR TITLE
Add an overwrite confimation popup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -512,14 +512,15 @@ export default class MediaDbPlugin extends Plugin {
 		// look if file already exists and ask if it should be overwritten
 		const file = this.app.vault.getAbstractFileByPath(filePath);
 		if (file) {
-			const shouldOverwrite = await new Promise<boolean>(resolve => {
-				new ConfirmOverwriteModal(this.app, fileName, resolve).open();
-			});
+			if (!options.isUpdating) {
+				const shouldOverwrite = await new Promise<boolean>(resolve => {
+					new ConfirmOverwriteModal(this.app, fileName, resolve).open();
+				});
 
-			if (!shouldOverwrite) {
-				throw new Error('MDB | file creation cancelled by user');
+				if (!shouldOverwrite) {
+					throw new Error('MDB | file creation cancelled by user');
+				}
 			}
-
 			await this.app.vault.delete(file);
 		}
 
@@ -574,9 +575,9 @@ export default class MediaDbPlugin extends Plugin {
 		console.debug(`MDB | newMediaTypeModel after merge`, newMediaTypeModel);
 
 		if (onlyMetadata) {
-			await this.createMediaDbNoteFromModel(newMediaTypeModel, { attachFile: activeFile, folder: activeFile.parent ?? undefined, openNote: true });
+			await this.createMediaDbNoteFromModel(newMediaTypeModel, { attachFile: activeFile, folder: activeFile.parent ?? undefined, openNote: true, isUpdating: true });
 		} else {
-			await this.createMediaDbNoteFromModel(newMediaTypeModel, { attachTemplate: true, folder: activeFile.parent ?? undefined, openNote: true });
+			await this.createMediaDbNoteFromModel(newMediaTypeModel, { attachTemplate: true, folder: activeFile.parent ?? undefined, openNote: true, isUpdating: true });
 		}
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -512,15 +512,14 @@ export default class MediaDbPlugin extends Plugin {
 		// look if file already exists and ask if it should be overwritten
 		const file = this.app.vault.getAbstractFileByPath(filePath);
 		if (file) {
-			if (!options.isUpdating) {
-				const shouldOverwrite = await new Promise<boolean>(resolve => {
-					new ConfirmOverwriteModal(this.app, fileName, resolve).open();
-				});
+			const shouldOverwrite = await new Promise<boolean>(resolve => {
+				new ConfirmOverwriteModal(this.app, fileName, resolve).open();
+			});
 
-				if (!shouldOverwrite) {
-					throw new Error('MDB | file creation cancelled by user');
-				}
+			if (!shouldOverwrite) {
+				throw new Error('MDB | file creation cancelled by user');
 			}
+
 			await this.app.vault.delete(file);
 		}
 
@@ -575,9 +574,9 @@ export default class MediaDbPlugin extends Plugin {
 		console.debug(`MDB | newMediaTypeModel after merge`, newMediaTypeModel);
 
 		if (onlyMetadata) {
-			await this.createMediaDbNoteFromModel(newMediaTypeModel, { attachFile: activeFile, folder: activeFile.parent ?? undefined, openNote: true, isUpdating: true });
+			await this.createMediaDbNoteFromModel(newMediaTypeModel, { attachFile: activeFile, folder: activeFile.parent ?? undefined, openNote: true });
 		} else {
-			await this.createMediaDbNoteFromModel(newMediaTypeModel, { attachTemplate: true, folder: activeFile.parent ?? undefined, openNote: true, isUpdating: true });
+			await this.createMediaDbNoteFromModel(newMediaTypeModel, { attachTemplate: true, folder: activeFile.parent ?? undefined, openNote: true });
 		}
 	}
 

--- a/src/modals/ConfirmOverwriteModal.ts
+++ b/src/modals/ConfirmOverwriteModal.ts
@@ -17,25 +17,23 @@ export class ConfirmOverwriteModal extends Modal {
 		contentEl.createEl('h2', { text: 'File already exists' });
 		contentEl.createEl('p', { text: `The file "${this.fileName}" already exists. Do you want to overwrite it?` });
 
-		const buttonContainer = contentEl.createDiv({ cls: 'modal-button-container' });
+		contentEl.createDiv({ cls: 'media-db-plugin-spacer' });
 
-		new Setting(buttonContainer)
-			.addButton(btn => {
-				btn.setButtonText('Yes');
-				btn.onClick(() => {
-					this.result = true;
-					this.close();
-				});
-				btn.buttonEl.addClass('media-db-plugin-button');
-			})
-			.addButton(btn => {
-				btn.setButtonText('No');
-				btn.onClick(() => {
-					this.result = false;
-					this.close();
-				});
-				btn.buttonEl.addClass('media-db-plugin-button');
+		const bottomSettingRow = new Setting(contentEl);
+		bottomSettingRow.addButton(btn => {
+			btn.setButtonText('Cancel');
+			btn.onClick(() => this.close());
+			btn.buttonEl.addClass('media-db-plugin-button');
+		});
+		bottomSettingRow.addButton(btn => {
+			btn.setButtonText('Ok');
+			btn.setCta();
+			btn.onClick(() => {
+				this.result = true;
+				this.close();
 			});
+			btn.buttonEl.addClass('media-db-plugin-button');
+		});
 	}
 
 	onClose() {

--- a/src/modals/ConfirmOverwriteModal.ts
+++ b/src/modals/ConfirmOverwriteModal.ts
@@ -1,0 +1,46 @@
+import type { App } from 'obsidian';
+import { Modal, Setting } from 'obsidian';
+
+export class ConfirmOverwriteModal extends Modal {
+	result: boolean = false;
+	onSubmit: (result: boolean) => void;
+	fileName: string;
+
+	constructor(app: App, fileName: string, onSubmit: (result: boolean) => void) {
+		super(app);
+		this.fileName = fileName;
+		this.onSubmit = onSubmit;
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.createEl('h2', { text: 'File already exists' });
+		contentEl.createEl('p', { text: `The file "${this.fileName}" already exists. Do you want to overwrite it?` });
+
+		const buttonContainer = contentEl.createDiv({ cls: 'modal-button-container' });
+
+		new Setting(buttonContainer)
+			.addButton(btn => {
+				btn.setButtonText('Yes');
+				btn.onClick(() => {
+					this.result = true;
+					this.close();
+				});
+				btn.buttonEl.addClass('media-db-plugin-button');
+			})
+			.addButton(btn => {
+				btn.setButtonText('No');
+				btn.onClick(() => {
+					this.result = false;
+					this.close();
+				});
+				btn.buttonEl.addClass('media-db-plugin-button');
+			});
+	}
+
+	onClose() {
+		const { contentEl } = this;
+		contentEl.empty();
+		this.onSubmit(this.result);
+	}
+}

--- a/src/modals/ConfirmOverwriteModal.ts
+++ b/src/modals/ConfirmOverwriteModal.ts
@@ -21,12 +21,12 @@ export class ConfirmOverwriteModal extends Modal {
 
 		const bottomSettingRow = new Setting(contentEl);
 		bottomSettingRow.addButton(btn => {
-			btn.setButtonText('Cancel');
+			btn.setButtonText('No');
 			btn.onClick(() => this.close());
 			btn.buttonEl.addClass('media-db-plugin-button');
 		});
 		bottomSettingRow.addButton(btn => {
-			btn.setButtonText('Ok');
+			btn.setButtonText('Yes');
 			btn.setCta();
 			btn.onClick(() => {
 				this.result = true;

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -193,7 +193,6 @@ export interface CreateNoteOptions {
 	attachFile?: TFile;
 	openNote?: boolean;
 	folder?: TFolder;
-	isUpdating?: boolean; // New property
 }
 
 export function migrateObject<T extends object>(object: T, oldData: any, defaultData: T): void {

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -193,6 +193,7 @@ export interface CreateNoteOptions {
 	attachFile?: TFile;
 	openNote?: boolean;
 	folder?: TFolder;
+	isUpdating?: boolean; // New property
 }
 
 export function migrateObject<T extends object>(object: T, oldData: any, defaultData: T): void {


### PR DESCRIPTION
To solve #167. The overwrite confirmation shows up when creating a new note and also when reloading the metadata for an existing notes.
![image](https://github.com/user-attachments/assets/b12fbfb6-8a11-4db0-a56b-64bdabbafc69)
