### PR TITLE
Openlibrary improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ## Obsidian Media DB Plugin
 
-A plugin that can query multiple APIs for movies, series, anime, manga, books, games, music and wiki articles, and import them into your vault.
+A plugin that can query multiple APIs for movies, series, anime, manga, books, comics, games, music and wiki articles, and import them into your vault.
 
 ### Features
 
 #### Search by Title
 
-Search a movie, series, anime, game, music release or wiki article by its name across multiple APIs.
+Search a movie, series, anime, manga, book, comic, game, music or wiki articles by its name across multiple APIs.
 
 #### Search by ID
 
@@ -164,9 +164,9 @@ Now you select the result you want and the plugin will cast it's magic and creat
 - [Open Library](https://openlibrary.org)
     - The ID can either be the "/work/" ID, the "/book/" ID, or the "/isbn/" ID it needs to start with `/works/`. You can find this ID in the URL
         - e.g. for "Fantastic Mr. Fox" the "/works/" URL looks like this `https://openlibrary.org/works/OL45804W` so the ID is `/works/OL45804W`
-        - This URL is located near the top of the page above the title, see `An edition of Fantastic Mr Fox (1970) `
+            - This URL is located near the top of the page above the title, see `An edition of Fantastic Mr Fox (1970) `
         - For a specific edition of "Fantastic Mr. Fox" the "/books/" URL looks like this `https://openlibrary.org/books/OL3567303M/` so the ID is `/books/OL3567303M`
-        - This URL is located in the editions section`
+            - This URL is located in the editions section`
 - [Moby Games](https://www.mobygames.com)
     - you can find this ID in the URL
         - e.g. for "Bioshock 2" the URL looks like this `https://www.mobygames.com/game/45089/bioshock-2/` so the ID is `45089`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A plugin that can query multiple APIs for movies, series, anime, manga, books, c
 
 #### Search by Title
 
-Search a movie, series, anime, manga, book, comic, game, music or wiki articles by its name across multiple APIs.
+Search a movie, series, anime, manga, book, comic, game, music release or wiki articles by its name across multiple APIs.
 
 #### Search by ID
 

--- a/README.md
+++ b/README.md
@@ -162,9 +162,11 @@ Now you select the result you want and the plugin will cast it's magic and creat
     - you can find this ID in the URL
         - e.g. for "Factorio" the URL looks like this `https://store.steampowered.com/app/427520/Factorio/` so the ID is `427520`
 - [Open Library](https://openlibrary.org)
-    - The ID you need is the "work" ID and not the "book" ID, it needs to start with `/works/`. You can find this ID in the URL
-        - e.g. for "Fantastic Mr. Fox" the URL looks like this `https://openlibrary.org/works/OL45804W` so the ID is `/works/OL45804W`
+    - The ID can either be the "/work/" ID, the "/book/" ID, or the "/isbn/" ID it needs to start with `/works/`. You can find this ID in the URL
+        - e.g. for "Fantastic Mr. Fox" the "/works/" URL looks like this `https://openlibrary.org/works/OL45804W` so the ID is `/works/OL45804W`
         - This URL is located near the top of the page above the title, see `An edition of Fantastic Mr Fox (1970) `
+        - For a specific edition of "Fantastic Mr. Fox" the "/books/" URL looks like this `https://openlibrary.org/books/OL3567303M/` so the ID is `/books/OL3567303M`
+        - This URL is located in the editions section`
 - [Moby Games](https://www.mobygames.com)
     - you can find this ID in the URL
         - e.g. for "Bioshock 2" the URL looks like this `https://www.mobygames.com/game/45089/bioshock-2/` so the ID is `45089`

--- a/src/api/apis/OpenLibraryAPI.ts
+++ b/src/api/apis/OpenLibraryAPI.ts
@@ -52,7 +52,7 @@ export class OpenLibraryAPI extends APIModel {
 	async getById(id: string): Promise<MediaTypeModel> {
 		console.log(`MDB | api "${this.apiName}" queried by ID`);
 
-		const searchUrl = `https://openlibrary.org/search.json?q=key:${encodeURIComponent(id)}`;
+		const searchUrl = `https://openlibrary.org/search.json?q=${encodeURIComponent(id)}&fields=key,title,author_name,number_of_pages_median,first_publish_year,isbn,ratings_score,first_sentence,title_suggest,rating*,cover_edition_key`;
 		const fetchData = await fetch(searchUrl);
 		// console.debug(fetchData);
 
@@ -68,8 +68,8 @@ export class OpenLibraryAPI extends APIModel {
 			title: result.title,
 			year: result.first_publish_year,
 			dataSource: this.apiName,
-			url: `https://openlibrary.org` + result.key,
-			id: result.key,
+			url: `https://openlibrary.org` + data.q,
+			id: data.q,
 			isbn: (result.isbn ?? []).find((el: string | any[]) => el.length <= 10) ?? 'unknown',
 			isbn13: (result.isbn ?? []).find((el: string | any[]) => el.length == 13) ?? 'unknown',
 			englishTitle: result.title_english ?? result.title,


### PR DESCRIPTION
 I noticed that the openlibrary api changed something making the the ratings, isbn, pages fields no longer work so I'm updated the search urls to re-enable them and also improved search by ID so users can add a specific edition (this fixes #175) or search by isbn.

Important note: You still can't search by title for specific editions, searching by title will always return the `/work/id`. Searching by id is for more advanced users so I don't want to complicate things or increase clutter for regular users.