### PR TITLE
Add country, boxOffice and ageRating fields for movies and series

### DIFF
--- a/src/api/apis/MALAPI.ts
+++ b/src/api/apis/MALAPI.ts
@@ -119,6 +119,9 @@ export class MALAPI extends APIModel {
 				image: result.images?.jpg?.image_url ?? '',
 
 				released: true,
+				country: [],
+				boxOffice: '',
+				ageRating: result.rating ?? '',
 				premiere: this.plugin.dateFormatter.format(result.aired?.from, this.apiDateFormat) ?? 'unknown',
 				streamingServices: result.streaming?.map((x: any) => x.name) ?? [],
 
@@ -151,6 +154,9 @@ export class MALAPI extends APIModel {
 				image: result.images?.jpg?.image_url ?? '',
 
 				released: true,
+				country: [],
+				boxOffice: '',
+				ageRating: result.rating ?? '',
 				premiere: this.plugin.dateFormatter.format(result.aired?.from, this.apiDateFormat) ?? 'unknown',
 				streamingServices: result.streaming?.map((x: any) => x.name) ?? [],
 
@@ -181,6 +187,8 @@ export class MALAPI extends APIModel {
 				image: result.images?.jpg?.image_url ?? '',
 
 				released: true,
+				country: [],
+				ageRating: result.rating ?? '',
 				airedFrom: this.plugin.dateFormatter.format(result.aired?.from, this.apiDateFormat) ?? 'unknown',
 				airedTo: this.plugin.dateFormatter.format(result.aired?.to, this.apiDateFormat) ?? 'unknown',
 				airing: result.airing,

--- a/src/api/apis/OMDbAPI.ts
+++ b/src/api/apis/OMDbAPI.ts
@@ -154,6 +154,9 @@ export class OMDbAPI extends APIModel {
 				image: result.Poster ? result.Poster.replace('_SX300', '_SX600') : '',
 
 				released: true,
+				country: result.Country?.split(', ') ?? [],
+				boxOffice: result.BoxOffice,
+				ageRating: result.Rated,
 				streamingServices: [],
 				premiere: this.plugin.dateFormatter.format(result.Released, this.apiDateFormat) ?? 'unknown',
 
@@ -184,6 +187,8 @@ export class OMDbAPI extends APIModel {
 				image: result.Poster ? result.Poster.replace('_SX300', '_SX600') : '',
 
 				released: true,
+				country: result.Country?.split(', ') ?? [],
+				ageRating: result.Rated,
 				streamingServices: [],
 				airing: false,
 				airedFrom: this.plugin.dateFormatter.format(result.Released, this.apiDateFormat) ?? 'unknown',

--- a/src/models/MovieModel.ts
+++ b/src/models/MovieModel.ts
@@ -17,6 +17,9 @@ export class MovieModel extends MediaTypeModel {
 	image: string;
 
 	released: boolean;
+	country: string[];
+	boxOffice: string;
+	ageRating: string;
 	streamingServices: string[];
 	premiere: string;
 
@@ -40,6 +43,9 @@ export class MovieModel extends MediaTypeModel {
 		this.image = '';
 
 		this.released = false;
+		this.country = [];
+		this.boxOffice = '';
+		this.ageRating = '';
 		this.streamingServices = [];
 		this.premiere = '';
 

--- a/src/models/SeriesModel.ts
+++ b/src/models/SeriesModel.ts
@@ -17,6 +17,8 @@ export class SeriesModel extends MediaTypeModel {
 	image: string;
 
 	released: boolean;
+	country: string[];
+	ageRating: string;
 	streamingServices: string[];
 	airing: boolean;
 	airedFrom: string;
@@ -42,6 +44,8 @@ export class SeriesModel extends MediaTypeModel {
 		this.image = '';
 
 		this.released = false;
+		this.country = [];
+		this.ageRating = '';
 		this.streamingServices = [];
 		this.airing = false;
 		this.airedFrom = '';


### PR DESCRIPTION
OMDbAPI has all 3 of these fields and MALAPI only has `ageRating`. While most anime is Japanese there are some Korean or Chinese anime also on MAL so I thought it best to just set `country` (and `boxOffice`) as empty. If anilistAPI (see #73) ever gets added then the `country` field could also be populated for anime series and movies.

`boxOffice` isn't applicable for series so I didn't add that field.

This fixes #169 and #75.