### PR TITLE
MusicBrainz: Limit cover art images to 500px

### DIFF
--- a/src/api/apis/MusicBrainzAPI.ts
+++ b/src/api/apis/MusicBrainzAPI.ts
@@ -51,7 +51,7 @@ export class MusicBrainzAPI extends APIModel {
 					dataSource: this.apiName,
 					url: 'https://musicbrainz.org/release-group/' + result.id,
 					id: result.id,
-					image: 'https://coverartarchive.org/release-group/' + result.id + '/front.jpg',
+					image: 'https://coverartarchive.org/release-group/' + result.id + '/front-500.jpg',
 
 					artists: result['artist-credit'].map((a: any) => a.name),
 					subType: result['primary-type'],
@@ -87,7 +87,7 @@ export class MusicBrainzAPI extends APIModel {
 			dataSource: this.apiName,
 			url: 'https://musicbrainz.org/release-group/' + result.id,
 			id: result.id,
-			image: 'https://coverartarchive.org/release-group/' + result.id + '/front.jpg',
+			image: 'https://coverartarchive.org/release-group/' + result.id + '/front-500.jpg',
 
 			artists: result['artist-credit'].map((a: any) => a.name),
 			genres: result.genres.map((g: any) => g.name),


### PR DESCRIPTION
By default, some MusicBrainz/Cover Art Archive images can be exceedingly large (4000x4000). This can cause performance issues with dataview as well as the [upcoming bases core plugin](https://help.obsidian.md/bases). There's also 1200px [available](https://wiki.musicbrainz.org/Cover_Art_Archive/API#/release-group/{mbid}/front[-(250|500|1200)]) if desired.