### PR TITLE
Clean up generated files names to remove or replace invalid characters

### DIFF
--- a/src/utils/MediaTypeManager.ts
+++ b/src/utils/MediaTypeManager.ts
@@ -71,7 +71,13 @@ export class MediaTypeManager {
 
 	getFileName(mediaTypeModel: MediaTypeModel): string {
 		// Ignore undefined tags since some search APIs do not return all properties in the model and produce clean file names even if errors occur
-		return replaceTags(this.mediaFileNameTemplateMap.get(mediaTypeModel.getMediaType())!, mediaTypeModel, true);
+		let fileName = replaceTags(this.mediaFileNameTemplateMap.get(mediaTypeModel.getMediaType())!, mediaTypeModel, true);
+		return this.cleanFileName(fileName);
+	}
+
+	cleanFileName(fileName: string) {
+		const invalidCharsRegex = /\™|\®|,|#|\[|\]|\||\^|\<|\>|\?|\*|\\|\//g;
+		return fileName.replaceAll(invalidCharsRegex, '').replaceAll(/"/g, "'").replaceAll(/:/g, ' -');
 	}
 
 	async getTemplate(mediaTypeModel: MediaTypeModel, app: App): Promise<string> {


### PR DESCRIPTION
Hi there - thanks for making such a great plugin!

I was running into some issues when trying to create markdown files based on media with titles that contain invalid filename characters (such as ":" and other punctuation).

This small change strips out most invalid characters, but replaces colons with hyphens, and replaces double quotes with single quotes, to try and retain the original intention as much as possible.

The original, unaltered, title is/can still be added to the frontmatter as per usual.