### PR TITLE
Allow batch / folder import by id as well as title

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import type { SearchModalOptions } from './utils/ModalHelper';
 import { ModalHelper, ModalResultCode } from './utils/ModalHelper';
 import type { CreateNoteOptions } from './utils/Utils';
 import { dateTimeToString, markdownTable, replaceIllegalFileNameCharactersInString, unCamelCase, hasTemplaterPlugin, useTemplaterPluginInFile } from './utils/Utils';
+import { BulkImportLookupMethod } from 'src/utils/BulkImportLookupMethod';
 
 export type Metadata = Record<string, unknown>;
 
@@ -646,7 +647,7 @@ export default class MediaDbPlugin extends Plugin {
 				if (!lookupValue || typeof lookupValue !== 'string') {
 					erroredFiles.push({ filePath: file.path, error: `metadata field '${fieldName}' not found, empty, or not a string` });
 					continue;
-				} else if (lookupMethod == 'id') {
+				} else if (lookupMethod === BulkImportLookupMethod.ID) {
 					try {
 						const model = await this.apiManager.queryDetailedInfoById(lookupValue, selectedAPI);
 						if (model) {
@@ -658,7 +659,7 @@ export default class MediaDbPlugin extends Plugin {
 						erroredFiles.push({ filePath: file.path, error: `${e}` });
 						continue;
 					}
-				} else if (lookupMethod == 'title') {
+				} else if (lookupMethod === BulkImportLookupMethod.TITLE) {
 					let results: MediaTypeModel[] = [];
 					try {
 						results = await this.apiManager.query(lookupValue, [selectedAPI]);
@@ -705,6 +706,9 @@ export default class MediaDbPlugin extends Plugin {
 					await this.createMediaDbNotes(detailedResults, appendContent ? file : undefined);
 
 					selectModal.close();
+				} else {
+					erroredFiles.push({ filePath: file.path, error: `invalid lookup type` });
+					continue;
 				}
 			}
 		}

--- a/src/modals/MediaDbFolderImportModal.ts
+++ b/src/modals/MediaDbFolderImportModal.ts
@@ -4,23 +4,25 @@ import type MediaDbPlugin from '../main';
 
 export class MediaDbFolderImportModal extends Modal {
 	plugin: MediaDbPlugin;
-	onSubmit: (selectedAPI: string, titleFieldName: string, appendContent: boolean) => void;
+	onSubmit: (selectedAPI: string, titleFieldName: string, idFieldName: string, appendContent: boolean) => void;
 	selectedApi: string;
 	searchBtn?: ButtonComponent;
 	titleFieldName: string;
+	idFieldName: string;
 	appendContent: boolean;
 
-	constructor(app: App, plugin: MediaDbPlugin, onSubmit: (selectedAPI: string, titleFieldName: string, appendContent: boolean) => void) {
+	constructor(app: App, plugin: MediaDbPlugin, onSubmit: (selectedAPI: string, titleFieldName: string, idFieldName: string, appendContent: boolean) => void) {
 		super(app);
 		this.plugin = plugin;
 		this.onSubmit = onSubmit;
 		this.selectedApi = plugin.apiManager.apis[0].apiName;
 		this.titleFieldName = '';
+		this.idFieldName = '';
 		this.appendContent = false;
 	}
 
 	submit(): void {
-		this.onSubmit(this.selectedApi, this.titleFieldName, this.appendContent);
+		this.onSubmit(this.selectedApi, this.titleFieldName, this.idFieldName, this.appendContent);
 		this.close();
 	}
 
@@ -43,7 +45,7 @@ export class MediaDbFolderImportModal extends Modal {
 		apiSelectorWrapper.appendChild(apiSelectorComponent.selectEl);
 
 		contentEl.createDiv({ cls: 'media-db-plugin-spacer' });
-		contentEl.createEl('h3', { text: 'Append note content to Media DB entry.' });
+		contentEl.createEl('h3', { text: 'Append note content to Media DB entry?' });
 
 		const appendContentToggleElementWrapper = contentEl.createEl('div', { cls: 'media-db-plugin-list-wrapper' });
 		const appendContentToggleTextWrapper = appendContentToggleElementWrapper.createEl('div', { cls: 'media-db-plugin-list-text-wrapper' });
@@ -60,7 +62,7 @@ export class MediaDbFolderImportModal extends Modal {
 		appendContentToggleComponentWrapper.appendChild(appendContentToggle.toggleEl);
 
 		contentEl.createDiv({ cls: 'media-db-plugin-spacer' });
-		contentEl.createEl('h3', { text: 'The name of the metadata field that should be used as the title to query.' });
+		contentEl.createEl('h3', { text: "Name of 'title' metadata field to use in API query." });
 
 		const placeholder = 'title';
 		const titleFieldNameComponent = new TextComponent(contentEl);
@@ -73,6 +75,20 @@ export class MediaDbFolderImportModal extends Modal {
 			}
 		});
 		contentEl.appendChild(titleFieldNameComponent.inputEl);
+
+		contentEl.createDiv({ cls: 'media-db-plugin-spacer' });
+		contentEl.createEl('h3', { text: "Name of 'id' metadata field to use in API query (if present, will be used instead of title)." });
+
+		const idFieldNameComponent = new TextComponent(contentEl);
+		idFieldNameComponent.inputEl.style.width = '100%';
+		idFieldNameComponent.setPlaceholder('id');
+		idFieldNameComponent.onChange(value => (this.idFieldName = value));
+		idFieldNameComponent.inputEl.addEventListener('keydown', ke => {
+			if (ke.key === 'Enter') {
+				this.submit();
+			}
+		});
+		contentEl.appendChild(idFieldNameComponent.inputEl);
 
 		contentEl.createDiv({ cls: 'media-db-plugin-spacer' });
 

--- a/src/modals/MediaDbFolderImportModal.ts
+++ b/src/modals/MediaDbFolderImportModal.ts
@@ -2,6 +2,7 @@ import type { App, ButtonComponent } from 'obsidian';
 import { DropdownComponent, Modal, Setting, TextComponent, ToggleComponent } from 'obsidian';
 import type MediaDbPlugin from '../main';
 import type { APIModel } from 'src/api/APIModel';
+import { BulkImportLookupMethod } from 'src/utils/BulkImportLookupMethod';
 
 export class MediaDbFolderImportModal extends Modal {
 	plugin: MediaDbPlugin;
@@ -17,7 +18,7 @@ export class MediaDbFolderImportModal extends Modal {
 		this.plugin = plugin;
 		this.onSubmit = onSubmit;
 		this.selectedApi = plugin.apiManager.apis[0].apiName;
-		this.lookupMethod = '';
+		this.lookupMethod = BulkImportLookupMethod.TITLE;
 		this.fieldName = '';
 		this.appendContent = false;
 	}
@@ -32,14 +33,16 @@ export class MediaDbFolderImportModal extends Modal {
 
 		contentEl.createEl('h2', { text: 'Import folder as Media DB entries' });
 
-		const onAPIChange = (value: string) => {
-			this.selectedApi = value;
-		};
-		const apiOptions = this.plugin.apiManager.apis.map((api: APIModel) => {
-			return { value: api.apiName, display: api.apiName };
-		});
-
-		this.createDropdownEl(contentEl, 'API to search', onAPIChange, apiOptions);
+		this.createDropdownEl(
+			contentEl,
+			'API to search',
+			(value: string) => {
+				this.selectedApi = value;
+			},
+			this.plugin.apiManager.apis.map((api: APIModel) => {
+				return { value: api.apiName, display: api.apiName };
+			}),
+		);
 
 		contentEl.createDiv({ cls: 'media-db-plugin-spacer' });
 		contentEl.createEl('h3', { text: 'Append note content to Media DB entry?' });
@@ -64,14 +67,17 @@ export class MediaDbFolderImportModal extends Modal {
 			text: 'Choose whether to search the API by title (can return multiple results) or lookup directly using an ID (returns at most one result), and specify the name of the frontmatter property which contains the title or ID of the media.',
 		});
 
-		const onlookupMethodChange = (value: string) => {
-			this.lookupMethod = value;
-		};
-		const lookupMethodOptions = [
-			{ value: 'title', display: 'Title' },
-			{ value: 'id', display: 'ID' },
-		];
-		this.createDropdownEl(contentEl, 'Lookup media by', onlookupMethodChange, lookupMethodOptions);
+		this.createDropdownEl(
+			contentEl,
+			'Lookup media by',
+			(value: string) => {
+				this.lookupMethod = value;
+			},
+			[
+				{ value: BulkImportLookupMethod.TITLE, display: 'Title' },
+				{ value: BulkImportLookupMethod.ID, display: 'ID' },
+			],
+		);
 
 		contentEl.createDiv({ cls: 'media-db-plugin-spacer' });
 
@@ -108,7 +114,7 @@ export class MediaDbFolderImportModal extends Modal {
 			});
 	}
 
-	createDropdownEl(parentEl: HTMLElement, label: string, onChange: { (value: string): void }, options: { value: string; display: string }[]): void {
+	createDropdownEl(parentEl: HTMLElement, label: string, onChange: (value: string) => void, options: { value: string; display: string }[]): void {
 		const wrapperEl = parentEl.createEl('div', { cls: 'media-db-plugin-list-wrapper' });
 		const labelWrapperEl = wrapperEl.createEl('div', { cls: 'media-db-plugin-list-text-wrapper' });
 		labelWrapperEl.createEl('span', { text: label, cls: 'media-db-plugin-list-text' });

--- a/src/utils/BulkImportLookupMethod.ts
+++ b/src/utils/BulkImportLookupMethod.ts
@@ -1,0 +1,4 @@
+export enum BulkImportLookupMethod {
+	ID = 'id',
+	TITLE = 'title',
+}


### PR DESCRIPTION
This proposed change adds an option to select an 'id' field to use when batch importing rather than the default 'title' field. Currently, the 'id' field takes priority over 'title' if it's added.

This allows for a fully automatic batch import without having to display a modal to allow the user to select the correct media from a list, since an ID can only match at most a single result.

I tested this by batch importing ~300 games from my Steam library, exported via the [Steam Web 'GetOwnedGames' API ](https://steamcommunity.com/dev) which provides Steam App IDs for an entire user library.

Not sure if this would be useful to anyone else, but thought I'd share just in case!

<img width="653" height="615" alt="image" src="https://github.com/user-attachments/assets/9757fb90-91c5-46f2-af72-3d19dac2b0af" />