### PR TITLE
Fix download image frontmatter formatting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -359,7 +359,7 @@ export default class MediaDbPlugin extends Plugin {
 				}
 
 				// Update model to use local image path
-				mediaTypeModel.image = `[[${imagePath}]]`;
+				mediaTypeModel.image = `"[[${imagePath}]]"`;
 				return true;
 			} catch (e) {
 				console.warn('MDB | Failed to download image:', e);


### PR DESCRIPTION
I noticed when using the option to automatically download remote images that Obsidian was complaining about invalid frontmatter. Currently the output I get looks like this:

```
image: 
  - - Attachments/Covers/game_Barbie Sparkling Ice Show (2002).jpg
```

<img width="822" height="54" alt="image" src="https://github.com/user-attachments/assets/b77a9ebb-f5d4-4910-bf11-733bfddf7c3c" />

Which is still readable by the new 'bases' core plugin, for instance, but by wrapping the output in quotation marks, Obsidian treats the local reference correctly as a string / local link:

```
image: "[[Attachments/Covers/game_Barbie Sparkling Ice Show (2002).jpg]]"
```
<img width="733" height="41" alt="image" src="https://github.com/user-attachments/assets/354f9a9c-bece-4ae3-b1ec-dd063823cb27" />

I'm not entirely sure why the output is being treated as (malformed?) list, so perhaps there is a better way to fix this?