### PR TITLE
Fix for double URI component encoding when querying GiantBomb API

### DIFF
--- a/src/api/apis/GiantBombAPI.ts
+++ b/src/api/apis/GiantBombAPI.ts
@@ -33,7 +33,7 @@ export class GiantBombAPI extends APIModel {
 			params: {
 				query: {
 					api_key: this.plugin.settings.GiantBombKey,
-					filter: `name:${encodeURIComponent(title)}`,
+					filter: `name:${title}`,
 					format: 'json',
 					limit: 20,
 				},


### PR DESCRIPTION
Me again 😅

I noticed that the Giantbomb API wasn't always returning results, even for things I knew were definitely in their database. Manually querying the API returned results as expected, so I did some digging.

It looks like `openapi-fetch` encodes query parameters automatically, so the manual call to `encodeURIComponent` was doubling up. For example, searching for "A Short Hike" generated this URL for the query:

```
https://www.giantbomb.com/api/games?api_key={REDACTED}&filter=name%3AA%2520Short%2520Hike&format=json&limit=20
```

Whereas what we want (`%20` for spaces, not `%2520`) is:

```
https://www.giantbomb.com/api/games?api_key={REDACTED}&filter=name%3AA%20Short%20Hike&format=json&limit=20
```

Which is what gets generated with this little fix in place.

<img width="626" height="446" alt="image" src="https://github.com/user-attachments/assets/407b1b01-db28-40b1-9f61-bcc7193ec0f6" />