### PR TITLE
Revert imagepath double quotes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -352,7 +352,7 @@ export default class MediaDbPlugin extends Plugin {
 				}
 
 				// Update model to use local image path
-				mediaTypeModel.image = `"[[${imagePath}]]"`;
+				mediaTypeModel.image = `[[${imagePath}]]`;
 				return true;
 			} catch (e) {
 				console.warn('MDB | Failed to download image:', e);


### PR DESCRIPTION
This reverts #208 to reinstate the correct formatting, I believe that the original issue needs further testing to find out why it created a nested list but adding the double quotes in the code breaks formatting for other users since Obsidian adds the double quotes by itself when using the plugin.