### PR TITLE
Add legacy api key popup so users can copy old keys

### DIFF
--- a/packages/obsidian/src/main.ts
+++ b/packages/obsidian/src/main.ts
@@ -173,7 +173,7 @@ export default class MediaDbPlugin extends Plugin {
 	}
 
 	private getLegacyApiKeyEntries(diskSettings: Record<string, unknown>): LegacyApiKeyEntry[] {
-		return LEGACY_API_KEYS.filter(key => typeof diskSettings[key] === 'string' && (diskSettings[key]).length > 0).map(key => ({
+		return LEGACY_API_KEYS.filter(key => typeof diskSettings[key] === 'string' && diskSettings[key].length > 0).map(key => ({
 			key,
 			value: diskSettings[key] as string,
 		}));
@@ -199,11 +199,13 @@ export default class MediaDbPlugin extends Plugin {
 
 		const legacyEntries = this.getLegacyApiKeyEntries(diskSettings);
 		if (legacyEntries.length > 0) {
-			this.app.workspace.onLayoutReady(() => {
-				window.setTimeout(() => {
-					new LegacyApiKeysModal(this.app, legacyEntries, async () => {
-						this.removeLegacyApiKeys(this.settings as unknown as Record<string, unknown>);
-						await this.saveSettings();
+			this.app.workspace.onLayoutReady((): void => {
+				window.setTimeout((): void => {
+					new LegacyApiKeysModal(this.app, legacyEntries, (): void => {
+						void (async (): Promise<void> => {
+							this.removeLegacyApiKeys(this.settings as unknown as Record<string, unknown>);
+							await this.saveSettings();
+						})();
 					}).open();
 				}, 0);
 			});

--- a/packages/obsidian/src/main.ts
+++ b/packages/obsidian/src/main.ts
@@ -16,6 +16,8 @@ import { TMDBSeasonAPI } from 'packages/obsidian/src/api/apis/TMDBSeasonAPI';
 import { TMDBSeriesAPI } from 'packages/obsidian/src/api/apis/TMDBSeriesAPI';
 import { VNDBAPI } from 'packages/obsidian/src/api/apis/VNDBAPI';
 import { WikipediaAPI } from 'packages/obsidian/src/api/apis/WikipediaAPI';
+import type { LegacyApiKeyEntry } from 'packages/obsidian/src/modals/LegacyApiKeysModal';
+import { LegacyApiKeysModal } from 'packages/obsidian/src/modals/LegacyApiKeysModal';
 import { PropertyMapper } from 'packages/obsidian/src/settings/PropertyMapper';
 import { PropertyMappingModel } from 'packages/obsidian/src/settings/PropertyMapping';
 import type { MediaDbPluginSettings } from 'packages/obsidian/src/settings/Settings';
@@ -30,6 +32,8 @@ import { MediaTypeManager } from 'packages/obsidian/src/utils/MediaTypeManager';
 import { MEDIA_TYPES } from 'packages/obsidian/src/utils/MediaTypeManager';
 import { ModalHelper } from 'packages/obsidian/src/utils/ModalHelper';
 import { unCamelCase } from 'packages/obsidian/src/utils/Utils';
+
+const LEGACY_API_KEYS = ['OMDbKey', 'TMDBKey', 'MobyGamesKey', 'GiantBombKey', 'ComicVineKey', 'BoardgameGeekKey'] as const;
 
 export default class MediaDbPlugin extends Plugin {
 	declare settings: MediaDbPluginSettings;
@@ -168,35 +172,42 @@ export default class MediaDbPlugin extends Plugin {
 		});
 	}
 
-	async loadSettings(): Promise<void> {
-		const diskSettings: MediaDbPluginSettings = (await this.loadData()) as MediaDbPluginSettings;
-		const defaultSettings: MediaDbPluginSettings = getDefaultSettings(this);
-		const loadedSettings: MediaDbPluginSettings = Object.assign({}, defaultSettings, diskSettings);
+	private getLegacyApiKeyEntries(diskSettings: Record<string, unknown>): LegacyApiKeyEntry[] {
+		return LEGACY_API_KEYS.filter(key => typeof diskSettings[key] === 'string' && (diskSettings[key]).length > 0).map(key => ({
+			key,
+			value: diskSettings[key] as string,
+		}));
+	}
 
-		// delete old api keys
-		// @ts-ignore
-		delete loadedSettings.BoardgameGeekKey;
-		// @ts-ignore
-		delete loadedSettings.ComicVineKey;
-		// @ts-ignore
-		delete loadedSettings.GiantBombKey;
-		// @ts-ignore
-		delete loadedSettings.MobyGamesKey;
-		// @ts-ignore
-		delete loadedSettings.OMDbKey;
-		// @ts-ignore
-		delete loadedSettings.TMDBKey;
+	private removeLegacyApiKeys(settings: Record<string, unknown>): void {
+		for (const key of LEGACY_API_KEYS) {
+			delete settings[key];
+		}
+	}
+
+	async loadSettings(): Promise<void> {
+		const diskSettings = (await this.loadData()) as Record<string, unknown>;
+		const defaultSettings: MediaDbPluginSettings = getDefaultSettings(this);
+		const loadedSettings = Object.assign({}, defaultSettings, diskSettings) as MediaDbPluginSettings;
 
 		const migratedModels = PropertyMappingModel.migrateModels(
 			loadedSettings.propertyMappingModels || [],
 			defaultSettings.propertyMappingModels.map(m => PropertyMappingModel.fromJSON(m)),
 		);
-
 		loadedSettings.propertyMappingModels = migratedModels.map(m => m.toJSON());
-
 		this.settings = loadedSettings;
 
-		await this.saveSettings();
+		const legacyEntries = this.getLegacyApiKeyEntries(diskSettings);
+		if (legacyEntries.length > 0) {
+			this.app.workspace.onLayoutReady(() => {
+				window.setTimeout(() => {
+					new LegacyApiKeysModal(this.app, legacyEntries, async () => {
+						this.removeLegacyApiKeys(this.settings as unknown as Record<string, unknown>);
+						await this.saveSettings();
+					}).open();
+				}, 0);
+			});
+		}
 	}
 
 	async saveSettings(): Promise<void> {

--- a/packages/obsidian/src/main.ts
+++ b/packages/obsidian/src/main.ts
@@ -33,8 +33,6 @@ import { MEDIA_TYPES } from 'packages/obsidian/src/utils/MediaTypeManager';
 import { ModalHelper } from 'packages/obsidian/src/utils/ModalHelper';
 import { unCamelCase } from 'packages/obsidian/src/utils/Utils';
 
-const LEGACY_API_KEYS = ['OMDbKey', 'TMDBKey', 'MobyGamesKey', 'GiantBombKey', 'ComicVineKey', 'BoardgameGeekKey'] as const;
-
 export default class MediaDbPlugin extends Plugin {
 	declare settings: MediaDbPluginSettings;
 	apiManager!: APIManager;
@@ -173,14 +171,14 @@ export default class MediaDbPlugin extends Plugin {
 	}
 
 	private getLegacyApiKeyEntries(diskSettings: Record<string, unknown>): LegacyApiKeyEntry[] {
-		return LEGACY_API_KEYS.filter(key => typeof diskSettings[key] === 'string' && diskSettings[key].length > 0).map(key => ({
+		return this.settings.LegacyApiKeys.filter(key => typeof diskSettings[key] === 'string' && diskSettings[key].length > 0).map(key => ({
 			key,
 			value: diskSettings[key] as string,
 		}));
 	}
 
 	private removeLegacyApiKeys(settings: Record<string, unknown>): void {
-		for (const key of LEGACY_API_KEYS) {
+		for (const key of this.settings.LegacyApiKeys) {
 			delete settings[key];
 		}
 	}
@@ -202,10 +200,8 @@ export default class MediaDbPlugin extends Plugin {
 			this.app.workspace.onLayoutReady((): void => {
 				window.setTimeout((): void => {
 					new LegacyApiKeysModal(this.app, legacyEntries, (): void => {
-						void (async (): Promise<void> => {
-							this.removeLegacyApiKeys(this.settings as unknown as Record<string, unknown>);
-							await this.saveSettings();
-						})();
+						this.removeLegacyApiKeys(this.settings as unknown as Record<string, unknown>);
+						void this.saveSettings();
 					}).open();
 				}, 0);
 			});

--- a/packages/obsidian/src/modals/LegacyApiKeysModal.ts
+++ b/packages/obsidian/src/modals/LegacyApiKeysModal.ts
@@ -2,90 +2,92 @@ import type { App } from 'obsidian';
 import { Modal, Setting, Notice } from 'obsidian';
 
 export interface LegacyApiKeyEntry {
-    key: string;
-    value: string;
+	key: string;
+	value: string;
 }
 
 export class LegacyApiKeysModal extends Modal {
-    private entries: LegacyApiKeyEntry[];
-    private onConfirm: () => void;
+	private entries: LegacyApiKeyEntry[];
+	private onConfirm: () => void;
 
-    constructor(app: App, entries: LegacyApiKeyEntry[], onConfirm: () => void) {
-        super(app);
-        this.entries = entries;
-        this.onConfirm = onConfirm;
-    }
+	constructor(app: App, entries: LegacyApiKeyEntry[], onConfirm: () => void) {
+		super(app);
+		this.entries = entries;
+		this.onConfirm = onConfirm;
+	}
 
-    onOpen(): void {
-        const { contentEl } = this;
-        contentEl.addClass('media-db-plugin-legacy-keys-modal');
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.addClass('media-db-plugin-legacy-keys-modal');
 
-        contentEl.createEl('h2', { text: 'Media DB plugin: Legacy API keys found' });
+		contentEl.createEl('h2', { text: 'Media DB plugin: Legacy API keys found' });
 
-        const wrapper = contentEl.createDiv({ cls: 'media-db-plugin-legacy-keys-wrapper' });
+		const wrapper = contentEl.createDiv({ cls: 'media-db-plugin-legacy-keys-wrapper' });
 
-        const intro = wrapper.createDiv({ cls: 'media-db-plugin-legacy-keys-intro' });
-        intro.createEl('p', {
-            text: 'Media DB plugin has found old plaintext API keys in your settings. Copy them now if needed, they should be removed for safety. The new keychain-backed system will be used instead. The plugin will not be usable until the old plaintext keys have been deleted.',
-        });
+		const intro = wrapper.createDiv({ cls: 'media-db-plugin-legacy-keys-intro' });
+		intro.createEl('p', {
+			text: 'Media DB plugin has found old plaintext API keys in your settings. Copy them now if needed, they should be removed for safety.',
+		});
 
-        const textarea = wrapper.createEl('textarea', {
-            cls: 'media-db-plugin-legacy-keys-textarea',
-            attr: {
-                readonly: 'true',
-                spellcheck: 'false',
-            },
-        });
+		intro.createEl('p', {
+			text: 'The new keychain-backed system will be used instead. The plugin will not be usable until the old plaintext keys have been deleted.',
+		});
 
-        textarea.value = this.entries.map(e => `${e.key}: ${e.value}`).join('\n');
-        textarea.style.display = 'none';
+		const textarea = wrapper.createEl('textarea', {
+			cls: 'media-db-plugin-legacy-keys-textarea',
+			attr: {
+				readonly: 'true',
+				spellcheck: 'false',
+			},
+		});
 
-        contentEl.createDiv({ cls: 'media-db-plugin-spacer' });
+		textarea.value = this.entries.map(e => `${e.key}: ${e.value}`).join('\n');
+		textarea.addClass('media-db-plugin-hidden');
 
-        const bottomSettingRow = new Setting(contentEl);
+		contentEl.createDiv({ cls: 'media-db-plugin-spacer' });
 
-        bottomSettingRow.addButton(btn => {
-            btn.setButtonText('Copy');
-            btn.onClick(async () => {
-                await navigator.clipboard.writeText(textarea.value);
-                new Notice('Legacy API keys copied to clipboard.');
-            });
-            btn.buttonEl.addClass('media-db-plugin-button');
-        });
+		const bottomSettingRow = new Setting(contentEl);
 
-        bottomSettingRow.addButton(btn => {
-            btn.setButtonText('Show keys');
+		bottomSettingRow.addButton(btn => {
+			btn.setButtonText('Copy');
+			btn.onClick(async () => {
+				await navigator.clipboard.writeText(textarea.value);
+				new Notice('Legacy API keys copied to clipboard.');
+			});
+			btn.buttonEl.addClass('media-db-plugin-button');
+		});
 
-            btn.onClick(() => {
-                const isHidden = textarea.style.display === 'none';
+		bottomSettingRow.addButton(btn => {
+			btn.setButtonText('Show keys');
 
-                if (isHidden) {
-                    textarea.style.display = '';
-                    btn.setButtonText('Hide keys');
-                } else {
-                    textarea.style.display = 'none';
-                    btn.setButtonText('Show keys');
-                }
-            });
+			btn.onClick(() => {
+				const isHidden = textarea.hasClass('media-db-plugin-hidden');
+				if (isHidden) {
+					textarea.removeClass('media-db-plugin-hidden');
+					btn.setButtonText('Hide keys');
+				} else {
+					textarea.addClass('media-db-plugin-hidden');
+					btn.setButtonText('Show keys');
+				}
+			});
 
-            btn.buttonEl.addClass('media-db-plugin-button');
-        });
+			btn.buttonEl.addClass('media-db-plugin-button');
+		});
 
-        bottomSettingRow.addButton(btn => {
-            btn.setButtonText('Delete plaintext keys');
-            btn.setCta();
-            btn.onClick(() => {
-                this.close();
-                this.onConfirm();
-            });
-            btn.buttonEl.addClass('media-db-plugin-button');
+		bottomSettingRow.addButton(btn => {
+			btn.setButtonText('Delete plaintext keys');
+			btn.setCta();
+			btn.onClick(() => {
+				this.close();
+				this.onConfirm();
+			});
+			btn.buttonEl.addClass('media-db-plugin-button');
 			btn.buttonEl.addClass('mod-warning');
 			btn.buttonEl.addClass('mod-danger');
+		});
+	}
 
-        });
-    }
-
-    onClose(): void {
-        this.contentEl.empty();
-    }
+	onClose(): void {
+		this.contentEl.empty();
+	}
 }

--- a/packages/obsidian/src/modals/LegacyApiKeysModal.ts
+++ b/packages/obsidian/src/modals/LegacyApiKeysModal.ts
@@ -1,0 +1,91 @@
+import type { App } from 'obsidian';
+import { Modal, Setting, Notice } from 'obsidian';
+
+export interface LegacyApiKeyEntry {
+    key: string;
+    value: string;
+}
+
+export class LegacyApiKeysModal extends Modal {
+    private entries: LegacyApiKeyEntry[];
+    private onConfirm: () => void;
+
+    constructor(app: App, entries: LegacyApiKeyEntry[], onConfirm: () => void) {
+        super(app);
+        this.entries = entries;
+        this.onConfirm = onConfirm;
+    }
+
+    onOpen(): void {
+        const { contentEl } = this;
+        contentEl.addClass('media-db-plugin-legacy-keys-modal');
+
+        contentEl.createEl('h2', { text: 'Media DB plugin: Legacy API keys found' });
+
+        const wrapper = contentEl.createDiv({ cls: 'media-db-plugin-legacy-keys-wrapper' });
+
+        const intro = wrapper.createDiv({ cls: 'media-db-plugin-legacy-keys-intro' });
+        intro.createEl('p', {
+            text: 'Media DB plugin has found old plaintext API keys in your settings. Copy them now if needed, they should be removed for safety. The new keychain-backed system will be used instead. The plugin will not be usable until the old plaintext keys have been deleted.',
+        });
+
+        const textarea = wrapper.createEl('textarea', {
+            cls: 'media-db-plugin-legacy-keys-textarea',
+            attr: {
+                readonly: 'true',
+                spellcheck: 'false',
+            },
+        });
+
+        textarea.value = this.entries.map(e => `${e.key}: ${e.value}`).join('\n');
+        textarea.style.display = 'none';
+
+        contentEl.createDiv({ cls: 'media-db-plugin-spacer' });
+
+        const bottomSettingRow = new Setting(contentEl);
+
+        bottomSettingRow.addButton(btn => {
+            btn.setButtonText('Copy');
+            btn.onClick(async () => {
+                await navigator.clipboard.writeText(textarea.value);
+                new Notice('Legacy API keys copied to clipboard.');
+            });
+            btn.buttonEl.addClass('media-db-plugin-button');
+        });
+
+        bottomSettingRow.addButton(btn => {
+            btn.setButtonText('Show keys');
+
+            btn.onClick(() => {
+                const isHidden = textarea.style.display === 'none';
+
+                if (isHidden) {
+                    textarea.style.display = '';
+                    btn.setButtonText('Hide keys');
+                } else {
+                    textarea.style.display = 'none';
+                    btn.setButtonText('Show keys');
+                }
+            });
+
+            btn.buttonEl.addClass('media-db-plugin-button');
+        });
+
+        bottomSettingRow.addButton(btn => {
+            btn.setButtonText('Delete plaintext keys');
+            btn.setCta();
+            btn.onClick(() => {
+                this.close();
+                this.onConfirm();
+            });
+            btn.buttonEl.addClass('media-db-plugin-button');
+			btn.buttonEl.addClass('mod-warning');
+			btn.buttonEl.addClass('mod-danger');
+
+        });
+    }
+
+    onClose(): void {
+        this.contentEl.empty();
+    }
+}

--- a/packages/obsidian/src/settings/Settings.ts
+++ b/packages/obsidian/src/settings/Settings.ts
@@ -58,6 +58,8 @@ export interface MediaDbPluginSettings {
 	ComicVineKeyId: string;
 	BoardgameGeekKeyId: string;
 
+	LegacyApiKeys: readonly ['OMDbKey', 'TMDBKey', 'MobyGamesKey', 'GiantBombKey', 'ComicVineKey', 'BoardgameGeekKey'];
+
 	sfwFilter: boolean;
 	templates: boolean;
 	customDateFormat: string;
@@ -316,6 +318,8 @@ const DEFAULT_SETTINGS: MediaDbPluginSettings = {
 	RAWGAPIKeyId: '',
 	ComicVineKeyId: '',
 	BoardgameGeekKeyId: '',
+
+	LegacyApiKeys: ['OMDbKey', 'TMDBKey', 'MobyGamesKey', 'GiantBombKey', 'ComicVineKey', 'BoardgameGeekKey'],
 
 	sfwFilter: true,
 	templates: true,

--- a/packages/obsidian/src/settings/Settings.ts
+++ b/packages/obsidian/src/settings/Settings.ts
@@ -50,8 +50,8 @@ function createPropertyMappingsDescription(): DocumentFragment {
 export interface MediaDbPluginSettings {
 	OMDbKeyId: string;
 	TMDBKeyId: string;
-	MobyGamesKeyId: string;
-	GiantBombKeyId: string;
+	//MobyGamesKeyId: string;
+	//GiantBombKeyId: string;
 	IGDBClientId: string;
 	IGDBClientSecret: string;
 	RAWGAPIKeyId: string;
@@ -69,12 +69,12 @@ export interface MediaDbPluginSettings {
 
 	BoardgameGeekAPI_disabledMediaTypes: MediaType[];
 	ComicVineAPI_disabledMediaTypes: MediaType[];
-	GiantBombAPI_disabledMediaTypes: MediaType[];
+	//GiantBombAPI_disabledMediaTypes: MediaType[];
 	IGDBAPI_disabledMediaTypes: MediaType[];
 	RAWGAPI_disabledMediaTypes: MediaType[];
 	MALAPI_disabledMediaTypes: MediaType[];
 	MALAPIManga_disabledMediaTypes: MediaType[];
-	MobyGamesAPI_disabledMediaTypes: MediaType[];
+	//MobyGamesAPI_disabledMediaTypes: MediaType[];
 	MusicBrainzAPI_disabledMediaTypes: MediaType[];
 	OMDbAPI_disabledMediaTypes: MediaType[];
 	OpenLibraryAPI_disabledMediaTypes: MediaType[];
@@ -309,8 +309,8 @@ class MediaTypeMappedSettings {
 const DEFAULT_SETTINGS: MediaDbPluginSettings = {
 	OMDbKeyId: '',
 	TMDBKeyId: '',
-	MobyGamesKeyId: '',
-	GiantBombKeyId: '',
+	//MobyGamesKeyId: '',
+	//GiantBombKeyId: '',
 	IGDBClientId: '',
 	IGDBClientSecret: '',
 	RAWGAPIKeyId: '',
@@ -328,12 +328,12 @@ const DEFAULT_SETTINGS: MediaDbPluginSettings = {
 
 	BoardgameGeekAPI_disabledMediaTypes: [],
 	ComicVineAPI_disabledMediaTypes: [],
-	GiantBombAPI_disabledMediaTypes: [],
+	//GiantBombAPI_disabledMediaTypes: [],
 	IGDBAPI_disabledMediaTypes: [],
 	RAWGAPI_disabledMediaTypes: [],
 	MALAPI_disabledMediaTypes: [],
 	MALAPIManga_disabledMediaTypes: [],
-	MobyGamesAPI_disabledMediaTypes: [],
+	//MobyGamesAPI_disabledMediaTypes: [],
 	MusicBrainzAPI_disabledMediaTypes: [],
 	OMDbAPI_disabledMediaTypes: [],
 	OpenLibraryAPI_disabledMediaTypes: [],
@@ -610,38 +610,38 @@ export class MediaDbSettingTab extends PluginSettingTab {
 						return component;
 					}),
 		);
-		apiKeyGroup.addSetting(
-			setting =>
-				void setting
-					.setName('Moby Games key')
-					.setDesc('API key for "www.mobygames.com".')
-					.addComponent(el => {
-						const component = new SecretComponent(this.app, el);
+		// apiKeyGroup.addSetting(
+		// 	setting =>
+		// 		void setting
+		// 			.setName('Moby Games key')
+		// 			.setDesc('API key for "www.mobygames.com".')
+		// 			.addComponent(el => {
+		// 				const component = new SecretComponent(this.app, el);
 
-						component.setValue(this.plugin.settings.MobyGamesKeyId).onChange(data => {
-							this.plugin.settings.MobyGamesKeyId = data;
-							void this.plugin.saveSettings();
-						});
+		// 				component.setValue(this.plugin.settings.MobyGamesKeyId).onChange(data => {
+		// 					this.plugin.settings.MobyGamesKeyId = data;
+		// 					void this.plugin.saveSettings();
+		// 				});
 
-						return component;
-					}),
-		);
-		apiKeyGroup.addSetting(
-			setting =>
-				void setting
-					.setName('Giant Bomb Key')
-					.setDesc('API key for "www.giantbomb.com".')
-					.addComponent(el => {
-						const component = new SecretComponent(this.app, el);
+		// 				return component;
+		// 			}),
+		// );
+		// apiKeyGroup.addSetting(
+		// 	setting =>
+		// 		void setting
+		// 			.setName('Giant Bomb Key')
+		// 			.setDesc('API key for "www.giantbomb.com".')
+		// 			.addComponent(el => {
+		// 				const component = new SecretComponent(this.app, el);
 
-						component.setValue(this.plugin.settings.GiantBombKeyId).onChange(data => {
-							this.plugin.settings.GiantBombKeyId = data;
-							void this.plugin.saveSettings();
-						});
+		// 				component.setValue(this.plugin.settings.GiantBombKeyId).onChange(data => {
+		// 					this.plugin.settings.GiantBombKeyId = data;
+		// 					void this.plugin.saveSettings();
+		// 				});
 
-						return component;
-					}),
-		);
+		// 				return component;
+		// 			}),
+		// );
 		apiKeyGroup.addSetting(
 			setting =>
 				void setting

--- a/packages/obsidian/src/styles.css
+++ b/packages/obsidian/src/styles.css
@@ -307,7 +307,7 @@ small.media-db-plugin-list-text {
 .media-db-plugin-legacy-keys-wrapper {
 	display: flex;
 	flex-direction: column;
-	gap: 0.75rem;
+	gap: var(--size-4-3);
 	width: 100%;
 	max-width: 100%;
 }
@@ -315,11 +315,11 @@ small.media-db-plugin-list-text {
 .media-db-plugin-legacy-keys-textarea {
 	width: 100%;
 	max-width: 100%;
-	min-height: 100px;
-	min-width: 500px;
+	min-height: var(--size-4-5);
+	min-width: var(--size-4-7);
 	box-sizing: border-box;
 	resize: vertical;
-	padding: 0.75rem;
+	padding: var(--size-4-3);
 	border-radius: var(--radius-s);
 	border: 1px solid var(--background-modifier-border);
 	background: var(--background-primary);
@@ -330,5 +330,5 @@ small.media-db-plugin-list-text {
 	white-space: pre;
 }
 .media-db-plugin-hidden {
-	display: none !important;
+	display: none;
 }

--- a/packages/obsidian/src/styles.css
+++ b/packages/obsidian/src/styles.css
@@ -295,3 +295,37 @@ small.media-db-plugin-list-text {
 	width: var(--checkbox-size);
 	height: var(--checkbox-size);
 }
+
+.media-db-plugin-legacy-keys-modal {
+	display: contents;
+}
+
+.media-db-plugin-legacy-keys-intro {
+	color: var(--text-normal);
+}
+
+.media-db-plugin-legacy-keys-wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	width: 100%;
+	max-width: 100%;
+}
+
+.media-db-plugin-legacy-keys-textarea {
+	width: 100%;
+	max-width: 100%;
+	min-height: 100px;
+	min-width: 500px;
+	box-sizing: border-box;
+	resize: vertical;
+	padding: 0.75rem;
+	border-radius: var(--radius-s);
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-primary);
+	color: var(--text-normal);
+	font-family: var(--font-monospace);
+	font-size: var(--font-ui-smaller);
+	line-height: 1.5;
+	white-space: pre;
+}

--- a/packages/obsidian/src/styles.css
+++ b/packages/obsidian/src/styles.css
@@ -329,3 +329,6 @@ small.media-db-plugin-list-text {
 	line-height: 1.5;
 	white-space: pre;
 }
+.media-db-plugin-hidden {
+	display: none !important;
+}


### PR DESCRIPTION
It'll show a pop up modal when legacy keys are found in data.json, the keys are hidden by default but the user can show them or just copy them. The old plaintext keys should be deleted for safety reasons

<img width="685" height="344" alt="image" src="https://github.com/user-attachments/assets/671c878e-010e-40e9-a649-ff36597df675" />
<img width="697" height="489" alt="image" src="https://github.com/user-attachments/assets/ee125558-e702-4640-b059-b65955644f8a" />
